### PR TITLE
Fix codebook sidebar previews

### DIFF
--- a/public/codebook_gallery.html
+++ b/public/codebook_gallery.html
@@ -1,0 +1,932 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Symbol Codebook Gallery</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: #111;
+        color: #f2f2f2;
+      }
+      body {
+        margin: 0;
+        padding: 2rem;
+        background: radial-gradient(circle at top, #1d2733, #05070b 60%);
+      }
+      h1 {
+        font-weight: 600;
+        margin-bottom: 1.5rem;
+        text-align: center;
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 1.5rem;
+      }
+      .cluster {
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        border-radius: 12px;
+        padding: 1rem;
+        background: rgba(13, 17, 23, 0.85);
+        box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+        backdrop-filter: blur(12px);
+        transition: transform 120ms ease, box-shadow 200ms ease;
+      }
+      .cluster:hover {
+        transform: translateY(-4px);
+        box-shadow: 0 20px 45px rgba(0, 0, 0, 0.4);
+      }
+      .cluster header {
+        margin-bottom: 0.75rem;
+      }
+      .cluster h2 {
+        margin: 0;
+        font-size: 1.1rem;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+      }
+      .media {
+        width: 100%;
+        aspect-ratio: 1 / 1;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 10px;
+        overflow: hidden;
+        margin-bottom: 0.75rem;
+        background: rgba(255, 255, 255, 0.04);
+      }
+      .media img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        display: block;
+      }
+      .media .missing {
+        font-size: 0.85rem;
+        color: rgba(255, 230, 150, 0.9);
+        padding: 0.5rem;
+        text-align: center;
+      }
+      .meta {
+        margin: 0;
+        display: grid;
+        grid-template-columns: auto 1fr;
+        column-gap: 0.75rem;
+        row-gap: 0.4rem;
+        font-size: 0.9rem;
+      }
+      .meta dt {
+        font-weight: 600;
+        color: rgba(255, 255, 255, 0.7);
+      }
+      .meta dd {
+        margin: 0;
+      }
+      .meta .warning {
+        color: #ffb65c;
+      }
+      footer {
+        margin-top: 2rem;
+        text-align: center;
+        font-size: 0.85rem;
+        color: rgba(255, 255, 255, 0.55);
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Symbol Codebook Gallery</h1>
+    <section class="grid">
+    <article class="cluster">
+      <header><h2>Cluster 0</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v15044gf0000d2iijmvog65i9etndc70_e020_010250_obj.jpg" alt="Cluster 0 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>H</dd>
+        <dt>Instances</dt><dd>216</dd>
+        <dt>Thumb file</dt><dd>v15044gf0000d2iijmvog65i9etndc70_e020_010250_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 1</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v15044gf0000d2js9uvog65r8b9dc63g_e083_041750_obj.jpg" alt="Cluster 1 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>AL</dd>
+        <dt>Instances</dt><dd>74</dd>
+        <dt>Thumb file</dt><dd>v15044gf0000d2js9uvog65r8b9dc63g_e083_041750_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 2</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v15044gf0000d2js9uvog65r8b9dc63g_e106_053250_obj.jpg" alt="Cluster 2 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>X</dd>
+        <dt>Instances</dt><dd>103</dd>
+        <dt>Thumb file</dt><dd>v15044gf0000d2js9uvog65r8b9dc63g_e106_053250_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 3</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v12044gd0000d2husv7og65snaorfbcg.mp4_e359_179749_obj.jpg" alt="Cluster 3 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>C</dd>
+        <dt>Instances</dt><dd>274</dd>
+        <dt>Thumb file</dt><dd>v12044gd0000d2husv7og65snaorfbcg.mp4_e359_179749_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 4</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v15044gf0000d2iijmvog65i9etndc70_e016_008250_obj.jpg" alt="Cluster 4 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>W</dd>
+        <dt>Instances</dt><dd>104</dd>
+        <dt>Thumb file</dt><dd>v15044gf0000d2iijmvog65i9etndc70_e016_008250_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 5</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/20250816_033400000_iOS_conv_e062_062500_obj.jpg" alt="Cluster 5 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>AD</dd>
+        <dt>Instances</dt><dd>85</dd>
+        <dt>Thumb file</dt><dd>20250816_033400000_iOS_conv_e062_062500_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 6</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v15044gf0000d2hjqh7og65nf6193bh0_e039_019750_obj.jpg" alt="Cluster 6 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>BN</dd>
+        <dt>Instances</dt><dd>4</dd>
+        <dt>Thumb file</dt><dd>v15044gf0000d2hjqh7og65nf6193bh0_e039_019750_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 7</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/20250812_034218000_iOS2.6_e034_020450_obj.jpg" alt="Cluster 7 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>AM</dd>
+        <dt>Instances</dt><dd>73</dd>
+        <dt>Thumb file</dt><dd>20250812_034218000_iOS2.6_e034_020450_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 8</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v12044gd0000d2husv7og65snaorfbcg.mp4_e173_086750_obj.jpg" alt="Cluster 8 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>E</dd>
+        <dt>Instances</dt><dd>254</dd>
+        <dt>Thumb file</dt><dd>v12044gd0000d2husv7og65snaorfbcg.mp4_e173_086750_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 9</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/Michelle_orb_video_e013_006750_obj.jpg" alt="Cluster 9 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>AP</dd>
+        <dt>Instances</dt><dd>64</dd>
+        <dt>Thumb file</dt><dd>Michelle_orb_video_e013_006750_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 10</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v15044gf0000d2hjqh7og65nf6193bh0_e031_015750_obj.jpg" alt="Cluster 10 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>BO</dd>
+        <dt>Instances</dt><dd>4</dd>
+        <dt>Thumb file</dt><dd>v15044gf0000d2hjqh7og65nf6193bh0_e031_015750_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 11</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v15044gf0000d2hjqh7og65nf6193bh0_e036_018250_obj.jpg" alt="Cluster 11 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>BI</dd>
+        <dt>Instances</dt><dd>6</dd>
+        <dt>Thumb file</dt><dd>v15044gf0000d2hjqh7og65nf6193bh0_e036_018250_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 12</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/Michelle_orb_video_e014_007250_obj.jpg" alt="Cluster 12 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>I</dd>
+        <dt>Instances</dt><dd>211</dd>
+        <dt>Thumb file</dt><dd>Michelle_orb_video_e014_007250_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 13</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v15044gf0000d2ie6rfog65qka6atq7g_e040_040500_obj.jpg" alt="Cluster 13 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>K</dd>
+        <dt>Instances</dt><dd>194</dd>
+        <dt>Thumb file</dt><dd>v15044gf0000d2ie6rfog65qka6atq7g_e040_040500_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 14</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/misc_00022_IMG_6523.png" alt="Cluster 14 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>BK</dd>
+        <dt>Instances</dt><dd>5</dd>
+        <dt>Thumb file</dt><dd>misc_00022_IMG_6523.png</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 15</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v15044gf0000d2ie6rfog65qka6atq7g_e108_108500_obj.jpg" alt="Cluster 15 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>V</dd>
+        <dt>Instances</dt><dd>114</dd>
+        <dt>Thumb file</dt><dd>v15044gf0000d2ie6rfog65qka6atq7g_e108_108500_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 16</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v12044gd0000d2hlm8fog65pe6sb3vm0_e024_012250_obj.jpg" alt="Cluster 16 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>BR</dd>
+        <dt>Instances</dt><dd>4</dd>
+        <dt>Thumb file</dt><dd>v12044gd0000d2hlm8fog65pe6sb3vm0_e024_012250_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 17</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/20250815_204153000_iOS4_e042_030834_obj.jpg" alt="Cluster 17 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>N</dd>
+        <dt>Instances</dt><dd>145</dd>
+        <dt>Thumb file</dt><dd>20250815_204153000_iOS4_e042_030834_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 18</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v15044gf0000d2ht9mnog65nf61i3sl0_e022_022500_obj.jpg" alt="Cluster 18 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>BJ</dd>
+        <dt>Instances</dt><dd>6</dd>
+        <dt>Thumb file</dt><dd>v15044gf0000d2ht9mnog65nf61i3sl0_e022_022500_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 19</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v15044gf0000d2j6b17og65tfia5e8sg_e036_036500_obj.jpg" alt="Cluster 19 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>M</dd>
+        <dt>Instances</dt><dd>163</dd>
+        <dt>Thumb file</dt><dd>v15044gf0000d2j6b17og65tfia5e8sg_e036_036500_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 20</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v15044gf0000d2iijmvog65i9etndc70_e011_005750_obj.jpg" alt="Cluster 20 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>P</dd>
+        <dt>Instances</dt><dd>134</dd>
+        <dt>Thumb file</dt><dd>v15044gf0000d2iijmvog65i9etndc70_e011_005750_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 21</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v15044gf0000d2hjqh7og65nf6193bh0_e048_024250_obj.jpg" alt="Cluster 21 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>BH</dd>
+        <dt>Instances</dt><dd>6</dd>
+        <dt>Thumb file</dt><dd>v15044gf0000d2hjqh7og65nf6193bh0_e048_024250_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 22</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/20250812_034218000_iOS2.6_e066_041050_obj.jpg" alt="Cluster 22 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>F</dd>
+        <dt>Instances</dt><dd>237</dd>
+        <dt>Thumb file</dt><dd>20250812_034218000_iOS2.6_e066_041050_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 23</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v15044gf0000d2ht9mnog65nf61i3sl0_e103_103500_obj.jpg" alt="Cluster 23 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>BW</dd>
+        <dt>Instances</dt><dd>3</dd>
+        <dt>Thumb file</dt><dd>v15044gf0000d2ht9mnog65nf61i3sl0_e103_103500_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 24</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/20250815_204153000_iOS3_e072_056400_obj.jpg" alt="Cluster 24 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>AJ</dd>
+        <dt>Instances</dt><dd>78</dd>
+        <dt>Thumb file</dt><dd>20250815_204153000_iOS3_e072_056400_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 25</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/20250812_034218000_iOS2.5_e049_037050_obj.jpg" alt="Cluster 25 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>BP</dd>
+        <dt>Instances</dt><dd>4</dd>
+        <dt>Thumb file</dt><dd>20250812_034218000_iOS2.5_e049_037050_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 26</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/20250816_033400000_iOS_conv_e044_044500_obj.jpg" alt="Cluster 26 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>AG</dd>
+        <dt>Instances</dt><dd>85</dd>
+        <dt>Thumb file</dt><dd>20250816_033400000_iOS_conv_e044_044500_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 27</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v15044gf0000d2ftmcfog65g2pr51j70_e020_010250_obj.jpg" alt="Cluster 27 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>AN</dd>
+        <dt>Instances</dt><dd>67</dd>
+        <dt>Thumb file</dt><dd>v15044gf0000d2ftmcfog65g2pr51j70_e020_010250_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 28</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v15044gf0000d2j6b17og65tfia5e8sg_e064_064500_obj.jpg" alt="Cluster 28 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>U</dd>
+        <dt>Instances</dt><dd>117</dd>
+        <dt>Thumb file</dt><dd>v15044gf0000d2j6b17og65tfia5e8sg_e064_064500_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 29</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/20250816_033400000_iOS_conv_e140_111449_obj.jpg" alt="Cluster 29 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>AK</dd>
+        <dt>Instances</dt><dd>77</dd>
+        <dt>Thumb file</dt><dd>20250816_033400000_iOS_conv_e140_111449_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 30</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v15044gf0000d2jt9vfog65vjgteco5g_e008_004250_obj.jpg" alt="Cluster 30 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>R</dd>
+        <dt>Instances</dt><dd>127</dd>
+        <dt>Thumb file</dt><dd>v15044gf0000d2jt9vfog65vjgteco5g_e008_004250_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 31</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v15044gf0000d2ie6rfog65qka6atq7g_e093_093500_obj.jpg" alt="Cluster 31 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>AH</dd>
+        <dt>Instances</dt><dd>80</dd>
+        <dt>Thumb file</dt><dd>v15044gf0000d2ie6rfog65qka6atq7g_e093_093500_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 32</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v12044gd0000d2husv7og65snaorfbcg_e051_051500_obj.jpg" alt="Cluster 32 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>AT</dd>
+        <dt>Instances</dt><dd>50</dd>
+        <dt>Thumb file</dt><dd>v12044gd0000d2husv7og65snaorfbcg_e051_051500_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 33</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v15044gf0000d2ht9mnog65nf61i3sl0_e000_000500_obj.jpg" alt="Cluster 33 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>BU</dd>
+        <dt>Instances</dt><dd>3</dd>
+        <dt>Thumb file</dt><dd>v15044gf0000d2ht9mnog65nf61i3sl0_e000_000500_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 34</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/20250812_034218000_iOS2_e008_005250_obj.jpg" alt="Cluster 34 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>AE</dd>
+        <dt>Instances</dt><dd>85</dd>
+        <dt>Thumb file</dt><dd>20250812_034218000_iOS2_e008_005250_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 35</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/20250815_204153000_iOS2_e041_002883_obj.jpg" alt="Cluster 35 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>O</dd>
+        <dt>Instances</dt><dd>143</dd>
+        <dt>Thumb file</dt><dd>20250815_204153000_iOS2_e041_002883_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 36</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v15044gf0000d2ht9mnog65nf61i3sl0_e001_001500_obj.jpg" alt="Cluster 36 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>BV</dd>
+        <dt>Instances</dt><dd>3</dd>
+        <dt>Thumb file</dt><dd>v15044gf0000d2ht9mnog65nf61i3sl0_e001_001500_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 37</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/20250812_034218000_iOS2_e010_006600_obj.jpg" alt="Cluster 37 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>B</dd>
+        <dt>Instances</dt><dd>293</dd>
+        <dt>Thumb file</dt><dd>20250812_034218000_iOS2_e010_006600_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 38</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/20250815_204153000_iOS2_e073_005016_obj.jpg" alt="Cluster 38 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>AC</dd>
+        <dt>Instances</dt><dd>87</dd>
+        <dt>Thumb file</dt><dd>20250815_204153000_iOS2_e073_005016_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 39</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/20250812_034218000_iOS_e035_041900_obj.jpg" alt="Cluster 39 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>G</dd>
+        <dt>Instances</dt><dd>236</dd>
+        <dt>Thumb file</dt><dd>20250812_034218000_iOS_e035_041900_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 40</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v15044gf0000d2j6b17og65tfia5e8sg_e033_033500_obj.jpg" alt="Cluster 40 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>J</dd>
+        <dt>Instances</dt><dd>201</dd>
+        <dt>Thumb file</dt><dd>v15044gf0000d2j6b17og65tfia5e8sg_e033_033500_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 41</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v15044gf0000d2ht9mnog65nf61i3sl0_e086_086500_obj.jpg" alt="Cluster 41 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>AO</dd>
+        <dt>Instances</dt><dd>65</dd>
+        <dt>Thumb file</dt><dd>v15044gf0000d2ht9mnog65nf61i3sl0_e086_086500_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 42</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v15044gf0000d2js9uvog65r8b9dc63g_e076_038250_obj.jpg" alt="Cluster 42 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>AR</dd>
+        <dt>Instances</dt><dd>52</dd>
+        <dt>Thumb file</dt><dd>v15044gf0000d2js9uvog65r8b9dc63g_e076_038250_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 43</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/20250816_033400000_iOS_conv_e028_028500_obj.jpg" alt="Cluster 43 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>BG</dd>
+        <dt>Instances</dt><dd>7</dd>
+        <dt>Thumb file</dt><dd>20250816_033400000_iOS_conv_e028_028500_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 44</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v15044gf0000d2gk20nog65g267kppig_e067_033750_obj.jpg" alt="Cluster 44 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>AB</dd>
+        <dt>Instances</dt><dd>87</dd>
+        <dt>Thumb file</dt><dd>v15044gf0000d2gk20nog65g267kppig_e067_033750_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 45</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/20250816_033400000_iOS_conv_e087_087500_obj.jpg" alt="Cluster 45 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>AY</dd>
+        <dt>Instances</dt><dd>40</dd>
+        <dt>Thumb file</dt><dd>20250816_033400000_iOS_conv_e087_087500_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 46</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v15044gf0000d2js9uvog65r8b9dc63g_e135_067750_obj.jpg" alt="Cluster 46 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>Q</dd>
+        <dt>Instances</dt><dd>128</dd>
+        <dt>Thumb file</dt><dd>v15044gf0000d2js9uvog65r8b9dc63g_e135_067750_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 47</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/misc_00029_IMG_6530.png" alt="Cluster 47 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>BF</dd>
+        <dt>Instances</dt><dd>9</dd>
+        <dt>Thumb file</dt><dd>misc_00029_IMG_6530.png</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 48</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v12044gd0000d2husv7og65snaorfbcg.mp4_e199_099700_obj.jpg" alt="Cluster 48 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>A</dd>
+        <dt>Instances</dt><dd>359</dd>
+        <dt>Thumb file</dt><dd>v12044gd0000d2husv7og65snaorfbcg.mp4_e199_099700_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 49</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v15044gf0000d2iifsnog65r86tlmk0g_e006_006500_obj.jpg" alt="Cluster 49 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>Z</dd>
+        <dt>Instances</dt><dd>102</dd>
+        <dt>Thumb file</dt><dd>v15044gf0000d2iifsnog65r86tlmk0g_e006_006500_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 50</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v15044gf0000d2ht9mnog65nf61i3sl0_e077_077500_obj.jpg" alt="Cluster 50 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>AX</dd>
+        <dt>Instances</dt><dd>46</dd>
+        <dt>Thumb file</dt><dd>v15044gf0000d2ht9mnog65nf61i3sl0_e077_077500_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 51</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/20250812_034218000_iOS2.6_e073_045950_obj.jpg" alt="Cluster 51 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>D</dd>
+        <dt>Instances</dt><dd>263</dd>
+        <dt>Thumb file</dt><dd>20250812_034218000_iOS2.6_e073_045950_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 52</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/20250812_034218000_iOS2.5_e025_021450_obj.jpg" alt="Cluster 52 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>BQ</dd>
+        <dt>Instances</dt><dd>4</dd>
+        <dt>Thumb file</dt><dd>20250812_034218000_iOS2.5_e025_021450_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 53</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v15044gf0000d2ftmcfog65g2pr51j70_e025_012750_obj.jpg" alt="Cluster 53 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>AV</dd>
+        <dt>Instances</dt><dd>47</dd>
+        <dt>Thumb file</dt><dd>v15044gf0000d2ftmcfog65g2pr51j70_e025_012750_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 54</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v15044gf0000d2gk20nog65g267kppig_e057_028750_obj.jpg" alt="Cluster 54 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>AF</dd>
+        <dt>Instances</dt><dd>85</dd>
+        <dt>Thumb file</dt><dd>v15044gf0000d2gk20nog65g267kppig_e057_028750_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 55</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v15044gf0000d2ht9mnog65nf61i3sl0_e132_132500_obj.jpg" alt="Cluster 55 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>Y</dd>
+        <dt>Instances</dt><dd>102</dd>
+        <dt>Thumb file</dt><dd>v15044gf0000d2ht9mnog65nf61i3sl0_e132_132500_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 56</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v15044gf0000d2js9uvog65r8b9dc63g_e040_020250_obj.jpg" alt="Cluster 56 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>AU</dd>
+        <dt>Instances</dt><dd>49</dd>
+        <dt>Thumb file</dt><dd>v15044gf0000d2js9uvog65r8b9dc63g_e040_020250_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 57</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v12044gd0000d2i0647og65vlmef6qv0_e051_025750_obj.jpg" alt="Cluster 57 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>BE</dd>
+        <dt>Instances</dt><dd>10</dd>
+        <dt>Thumb file</dt><dd>v12044gd0000d2i0647og65vlmef6qv0_e051_025750_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 58</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v15044gf0000d2j6b17og65tfia5e8sg_e017_017500_obj.jpg" alt="Cluster 58 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>AW</dd>
+        <dt>Instances</dt><dd>47</dd>
+        <dt>Thumb file</dt><dd>v15044gf0000d2j6b17og65tfia5e8sg_e017_017500_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 59</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v15044gf0000d2js9uvog65r8b9dc63g_e142_071250_obj.jpg" alt="Cluster 59 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>BD</dd>
+        <dt>Instances</dt><dd>30</dd>
+        <dt>Thumb file</dt><dd>v15044gf0000d2js9uvog65r8b9dc63g_e142_071250_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 60</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/20250816_033400000_iOS_conv_e068_033950_obj.jpg" alt="Cluster 60 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>BL</dd>
+        <dt>Instances</dt><dd>5</dd>
+        <dt>Thumb file</dt><dd>20250816_033400000_iOS_conv_e068_033950_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 61</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v15044gf0000d2js9uvog65r8b9dc63g_e092_046250_obj.jpg" alt="Cluster 61 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>BA</dd>
+        <dt>Instances</dt><dd>39</dd>
+        <dt>Thumb file</dt><dd>v15044gf0000d2js9uvog65r8b9dc63g_e092_046250_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 62</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v15044gf0000d2ie6rfog65qka6atq7g_e069_069500_obj.jpg" alt="Cluster 62 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>T</dd>
+        <dt>Instances</dt><dd>120</dd>
+        <dt>Thumb file</dt><dd>v15044gf0000d2ie6rfog65qka6atq7g_e069_069500_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 63</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v15044gf0000d2fr3lfog65rbo3ud6jg_e022_011250_obj.jpg" alt="Cluster 63 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>S</dd>
+        <dt>Instances</dt><dd>121</dd>
+        <dt>Thumb file</dt><dd>v15044gf0000d2fr3lfog65rbo3ud6jg_e022_011250_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 64</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/20250815_204153000_iOS2_e018_001350_obj.jpg" alt="Cluster 64 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>AS</dd>
+        <dt>Instances</dt><dd>51</dd>
+        <dt>Thumb file</dt><dd>20250815_204153000_iOS2_e018_001350_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 65</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/20250815_204153000_iOS3_e025_022050_obj.jpg" alt="Cluster 65 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>AQ</dd>
+        <dt>Instances</dt><dd>53</dd>
+        <dt>Thumb file</dt><dd>20250815_204153000_iOS3_e025_022050_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 66</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v15044gf0000d2js9uvog65r8b9dc63g_e002_001250_obj.jpg" alt="Cluster 66 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>BB</dd>
+        <dt>Instances</dt><dd>34</dd>
+        <dt>Thumb file</dt><dd>v15044gf0000d2js9uvog65r8b9dc63g_e002_001250_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 67</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v15044gf0000d2ie6rfog65qka6atq7g_e071_071500_obj.jpg" alt="Cluster 67 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>AI</dd>
+        <dt>Instances</dt><dd>79</dd>
+        <dt>Thumb file</dt><dd>v15044gf0000d2ie6rfog65qka6atq7g_e071_071500_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 68</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v15044gf0000d2ht9mnog65nf61i3sl0_e106_106500_obj.jpg" alt="Cluster 68 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>AZ</dd>
+        <dt>Instances</dt><dd>40</dd>
+        <dt>Thumb file</dt><dd>v15044gf0000d2ht9mnog65nf61i3sl0_e106_106500_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 69</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v15044gf0000d2js9uvog65r8b9dc63g_e099_049750_obj.jpg" alt="Cluster 69 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>BC</dd>
+        <dt>Instances</dt><dd>33</dd>
+        <dt>Thumb file</dt><dd>v15044gf0000d2js9uvog65r8b9dc63g_e099_049750_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 70</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v15044gf0000d2ie6rfog65qka6atq7g_e041_041500_obj.jpg" alt="Cluster 70 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>AA</dd>
+        <dt>Instances</dt><dd>91</dd>
+        <dt>Thumb file</dt><dd>v15044gf0000d2ie6rfog65qka6atq7g_e041_041500_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 71</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v15044gf0000d2js9uvog65r8b9dc63g_e038_019250_obj.jpg" alt="Cluster 71 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>L</dd>
+        <dt>Instances</dt><dd>177</dd>
+        <dt>Thumb file</dt><dd>v15044gf0000d2js9uvog65r8b9dc63g_e038_019250_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 72</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/Michelle_orb_video_e023_011750_obj.jpg" alt="Cluster 72 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>BT</dd>
+        <dt>Instances</dt><dd>4</dd>
+        <dt>Thumb file</dt><dd>Michelle_orb_video_e023_011750_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 73</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v15044gf0000d2hjqh7og65nf6193bh0_e001_000750_obj.jpg" alt="Cluster 73 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>BS</dd>
+        <dt>Instances</dt><dd>4</dd>
+        <dt>Thumb file</dt><dd>v15044gf0000d2hjqh7og65nf6193bh0_e001_000750_obj.jpg</dd>
+      </dl>
+    </article>
+    <article class="cluster">
+      <header><h2>Cluster 74</h2></header>
+      <div class="media">
+        <img src="thumbs_obj/v15044gf0000d2iifsnog65r86tlmk0g_e054_054500_obj.jpg" alt="Cluster 74 thumbnail">
+      </div>
+      <dl class="meta">
+        <dt>Token</dt><dd>BM</dd>
+        <dt>Instances</dt><dd>4</dd>
+        <dt>Thumb file</dt><dd>v15044gf0000d2iifsnog65r86tlmk0g_e054_054500_obj.jpg</dd>
+      </dl>
+    </article>
+    </section>
+    <footer>
+      Generated by tools/generate_codebook_gallery.py
+    </footer>
+  </body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -43,6 +43,186 @@
             margin-left: 8px
         }
 
+        .codebook-sidebar {
+            position: fixed;
+            top: 86px;
+            right: 16px;
+            width: 260px;
+            max-height: calc(100vh - 120px);
+            background: var(--card);
+            border: 1px solid var(--border);
+            border-radius: 12px;
+            box-shadow: 0 18px 40px rgba(0, 0, 0, 0.35);
+            z-index: 30;
+            display: flex;
+            flex-direction: column;
+            overflow: hidden;
+            transition: transform .25s ease, opacity .2s ease;
+        }
+
+        .codebook-sidebar.collapsed {
+            transform: translateX(calc(100% + 24px));
+            opacity: 0;
+            pointer-events: none;
+        }
+
+        .codebook-sidebar .sidebar-header {
+            position: sticky;
+            top: 0;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 12px;
+            padding: 12px;
+            background: var(--card);
+            border-bottom: 1px solid var(--border);
+            z-index: 1;
+        }
+
+        .codebook-sidebar .sidebar-title {
+            font-weight: 600;
+            font-size: 14px;
+            letter-spacing: .04em;
+            text-transform: uppercase;
+        }
+
+        .codebook-sidebar .sidebar-subtitle {
+            display: block;
+            margin-top: 2px;
+            font-size: 11px;
+            color: var(--muted);
+        }
+
+        .codebook-sidebar .sidebar-body {
+            padding: 10px;
+            overflow-y: auto;
+            display: grid;
+            gap: 8px;
+        }
+
+        .codebook-entry {
+            display: grid;
+            grid-template-columns: 56px 1fr;
+            gap: 10px;
+            align-items: center;
+            width: 100%;
+            padding: 6px;
+            background: var(--chip);
+            border: 1px solid var(--border);
+            border-radius: 10px;
+            color: inherit;
+            text-align: left;
+            cursor: pointer;
+            transition: border-color .15s ease, transform .15s ease;
+        }
+
+        .codebook-entry:hover {
+            border-color: #395072;
+            transform: translateY(-1px);
+        }
+
+        .codebook-entry.busy {
+            opacity: .6;
+            pointer-events: none;
+        }
+
+        .codebook-entry .preview {
+            width: 56px;
+            height: 56px;
+            border-radius: 8px;
+            overflow: hidden;
+            background: #05070b;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .codebook-entry .preview img {
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+        }
+
+        .codebook-entry .preview .missing-thumb {
+            font-size: 11px;
+            color: var(--muted);
+            text-align: center;
+            padding: 6px;
+        }
+
+        .codebook-entry .info {
+            display: flex;
+            flex-direction: column;
+            gap: 2px;
+        }
+
+        .codebook-entry .info strong {
+            font-size: 12px;
+            letter-spacing: .02em;
+        }
+
+        .codebook-entry .info small {
+            font-size: 11px;
+            color: var(--muted);
+        }
+
+        .sidebar-empty {
+            padding: 12px;
+            font-size: 12px;
+            color: var(--muted);
+            text-align: center;
+        }
+
+        .sidebar-drop {
+            padding: 6px 10px;
+            border-radius: 999px;
+            border: 1px solid var(--border);
+            background: transparent;
+            color: var(--muted);
+            cursor: pointer;
+            font-size: 11px;
+            letter-spacing: .04em;
+            text-transform: uppercase;
+        }
+
+        .sidebar-drop:hover {
+            color: var(--fg);
+            border-color: #395072;
+        }
+
+        #codebookToggle {
+            position: fixed;
+            right: 16px;
+            bottom: 20px;
+            display: none;
+            padding: 10px 14px;
+            border-radius: 999px;
+            border: 1px solid var(--border);
+            background: var(--card);
+            color: var(--fg);
+            cursor: pointer;
+            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+            z-index: 30;
+        }
+
+        #codebookToggle:hover {
+            border-color: #395072;
+        }
+
+        .codebook-sidebar.collapsed + #codebookToggle {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+        }
+
+        @media (max-width: 900px) {
+            .codebook-sidebar {
+                width: min(90vw, 260px);
+                top: auto;
+                bottom: 80px;
+            }
+        }
+
         .controls {
             display: flex;
             flex-wrap: wrap;
@@ -407,6 +587,20 @@
         <button id="donateBtn" class="pill" title="Donate">Donate</button>
     </header>
 
+    <aside id="codebookSidebar" class="codebook-sidebar" tabindex="-1">
+        <div class="sidebar-header">
+            <div>
+                <div class="sidebar-title">Symbol Codebook</div>
+                <span class="sidebar-subtitle">Cluster prototypes</span>
+            </div>
+            <button id="codebookDrop" class="sidebar-drop" type="button">Drop</button>
+        </div>
+        <div class="sidebar-body">
+            <div class="sidebar-empty">Loading codebook…</div>
+        </div>
+    </aside>
+    <button id="codebookToggle" class="codebook-toggle" type="button">Codebook</button>
+
     <div class="controls">
         <div class="group">
             <label for="sizeRange">Tile size</label>
@@ -644,6 +838,21 @@
         const svgCache = {}; // key -> resolved successful URL
         const SEQ_CACHE = new Map();
 
+        const CODEBOOK_URL = "sequences_merge/symbol_codebook.json";
+        let CODEBOOK_CLUSTERS = [];
+        const CODEBOOK_PROMISE = loadCodebookData().then(clusters => {
+            CODEBOOK_CLUSTERS = clusters;
+            return clusters;
+        });
+
+        const THUMB_TO_INDEX = new Map();
+        let resolveDataReady;
+        const dataReady = new Promise(resolve => { resolveDataReady = resolve; });
+
+        const sequenceClusterPromises = new Map();
+        const CLUSTER_MEMBERS = new Map();
+        const CLUSTER_WINDOW_FEATURES = "width=980,height=720,resizable=yes,scrollbars=yes";
+
         function sequenceJsonURL(jsonFile) {
             if (!jsonFile) return null;
             const safe = String(jsonFile).split('/').map(part => encodeURIComponent(part)).join('/');
@@ -668,6 +877,334 @@
             SEQ_CACHE.set(jsonFile, prom);
             return prom;
         }
+
+        async function loadCodebookData() {
+            try {
+                const res = await fetch(CODEBOOK_URL, { cache: "force-cache" });
+                if (!res.ok) throw new Error(`HTTP ${res.status}`);
+                const text = await res.text();
+                const safe = text.replace(/\bNaN\b/g, "null");
+                const data = JSON.parse(safe);
+                const clusters = Array.isArray(data?.clusters) ? data.clusters : [];
+                return clusters.map(cluster => ({
+                    cluster_id: Number(cluster.cluster_id),
+                    token: cluster.token || "",
+                    count: Number(cluster.count) || 0,
+                    thumb_obj: normalizeThumbName(cluster?.prototype?.thumb_obj || "")
+                }));
+            } catch (err) {
+                console.warn('codebook fetch failed', err);
+                return [];
+            }
+        }
+
+        function rebuildThumbIndex() {
+            THUMB_TO_INDEX.clear();
+            DATA.forEach((it, idx) => {
+                const key = normalizeThumbName(it.thumb_obj);
+                if (key && !THUMB_TO_INDEX.has(key)) {
+                    THUMB_TO_INDEX.set(key, idx);
+                }
+            });
+        }
+
+        function ensureSequenceClusters(jsonFile) {
+            if (!jsonFile) return Promise.resolve();
+            if (sequenceClusterPromises.has(jsonFile)) return sequenceClusterPromises.get(jsonFile);
+            const prom = loadSequenceMetadata(jsonFile).then(seq => {
+                if (!seq || !Array.isArray(seq.events)) return;
+                seq.events.forEach(ev => {
+                    const cid = Number(ev.cluster_id);
+                    const thumb = normalizeThumbName(ev.thumb_obj);
+                    if (!Number.isFinite(cid) || !thumb) return;
+                    let arr = CLUSTER_MEMBERS.get(cid);
+                    if (!arr) {
+                        arr = [];
+                        CLUSTER_MEMBERS.set(cid, arr);
+                    }
+                    if (!arr.some(item => item.thumb_obj === thumb)) {
+                        arr.push({
+                            thumb_obj: thumb,
+                            json_file: jsonFile,
+                            event_index: ev.event_index
+                        });
+                    }
+                });
+            }).catch(err => {
+                console.warn('cluster mapping failed', err);
+            });
+            sequenceClusterPromises.set(jsonFile, prom);
+            return prom;
+        }
+
+        async function fetchClusterMembers(clusterId) {
+            await dataReady;
+            const files = Array.from(new Set(DATA.map(it => it.json_file).filter(Boolean)));
+            if (files.length) {
+                await Promise.all(files.map(ensureSequenceClusters));
+            }
+            const entries = (CLUSTER_MEMBERS.get(clusterId) || []).map(item => ({ ...item }));
+            entries.sort((a, b) => {
+                const aj = (a.json_file || "").toLowerCase();
+                const bj = (b.json_file || "").toLowerCase();
+                if (aj !== bj) return aj < bj ? -1 : 1;
+                const ai = Number(a.event_index);
+                const bi = Number(b.event_index);
+                if (Number.isFinite(ai) && Number.isFinite(bi)) return ai - bi;
+                return String(a.event_index).localeCompare(String(b.event_index));
+            });
+            return entries;
+        }
+
+        async function openClusterWindow(cluster, preOpenedWindow) {
+            const name = `codebook_cluster_${cluster?.cluster_id ?? ""}`;
+            const win = preOpenedWindow || window.open("", name, CLUSTER_WINDOW_FEATURES);
+            if (!win) {
+                toast("Please allow pop-ups for cluster viewer.");
+                return;
+            }
+            try {
+                if (!preOpenedWindow) {
+                    win.document.write("<!doctype html><title>Loading…</title><body style='background:#0b0d12;color:#c9d3e5;font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;padding:24px;'>Loading cluster…</body>");
+                    win.document.close();
+                }
+                await dataReady;
+                const members = await fetchClusterMembers(cluster.cluster_id);
+                const enriched = members.map(item => {
+                    const idx = THUMB_TO_INDEX.get(item.thumb_obj);
+                    const row = (typeof idx === "number") ? DATA[idx] : null;
+                    const scenePath = row ? sanitizeRelativePath(row.thumb) : "";
+                    const objectPath = row ? sanitizeRelativePath(row.thumb_obj) : sanitizeRelativePath(item.thumb_obj);
+                    return {
+                        thumb_obj: objectPath || item.thumb_obj,
+                        thumb_scene: scenePath,
+                        json_file: item.json_file,
+                        event_index: item.event_index,
+                        dataIdx: (typeof idx === "number") ? idx : null
+                    };
+                });
+                const payload = {
+                    cluster: {
+                        id: cluster.cluster_id,
+                        token: cluster.token || "",
+                        count: cluster.count || enriched.length
+                    },
+                    items: enriched
+                };
+                const payloadStr = JSON.stringify(payload).replace(/</g, "\\u003c");
+                const clusterTitle = cluster.token ? `Cluster ${cluster.cluster_id} • ${cluster.token}` : `Cluster ${cluster.cluster_id}`;
+                const memberCount = payload.cluster.count;
+                if (win.closed) return;
+                const html = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>${clusterTitle}</title>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<style>
+:root { color-scheme: dark; font-family: system-ui,-apple-system,Segoe UI,Roboto,sans-serif; background:#0b0d12; color:#e7eaf0; }
+body { margin:0; background:#0b0d12; color:#e7eaf0; }
+header { padding:16px 20px; border-bottom:1px solid #243041; display:flex; flex-wrap:wrap; gap:12px; align-items:center; }
+header h1 { font-size:16px; margin:0; }
+header span { font-size:12px; color:#9aa3b2; }
+header button { margin-left:auto; padding:6px 10px; border-radius:999px; border:1px solid #243041; background:#131722; color:#e7eaf0; cursor:pointer; }
+header button:hover { border-color:#395072; }
+main { padding:18px; }
+.grid { display:grid; gap:14px; grid-template-columns:repeat(auto-fill,minmax(160px,1fr)); }
+.cluster-card { background:#131722; border:1px solid #243041; border-radius:12px; overflow:hidden; display:flex; flex-direction:column; }
+.cluster-card button { padding:0; border:0; background:none; color:inherit; text-align:left; cursor:pointer; display:flex; flex-direction:column; height:100%; }
+.cluster-card button:focus-visible { outline:2px solid #58a6ff; outline-offset:2px; }
+.cluster-card img { width:100%; aspect-ratio:1/1; object-fit:cover; background:#000; }
+.cluster-card .meta { padding:10px 12px; font-size:12px; line-height:1.4; color:#c9d3e5; display:flex; flex-direction:column; gap:4px; }
+.cluster-card .status { font-size:11px; color:#9aa3b2; }
+.empty { padding:40px 0; text-align:center; color:#9aa3b2; font-size:13px; }
+</style>
+</head>
+<body>
+<header>
+  <h1>${clusterTitle}</h1>
+  <span>${memberCount} total members</span>
+  <button id="focusMain" type="button">Focus main viewer</button>
+</header>
+<main>
+  <div id="clusterGrid" class="grid"></div>
+</main>
+<script>
+const PAYLOAD = ${payloadStr};
+function encodePath(name){ return name ? name.split('/').map(encodeURIComponent).join('/') : ''; }
+function focusMain(){ if (window.opener && !window.opener.closed){ window.opener.focus(); } }
+function handleClick(name){
+  if (window.opener && !window.opener.closed && typeof window.opener.handleCodebookSelection === 'function'){
+    window.opener.focus();
+    window.opener.handleCodebookSelection(name);
+  } else {
+    alert('Main viewer not available.');
+  }
+}
+document.getElementById('focusMain').addEventListener('click', focusMain);
+(function render(){
+  const grid = document.getElementById('clusterGrid');
+  if (!grid) return;
+  if (!PAYLOAD.items.length){
+    grid.outerHTML = '<p class="empty">No thumb.obj members were found for this cluster.</p>';
+    return;
+  }
+  const frag = document.createDocumentFragment();
+  PAYLOAD.items.forEach(item => {
+    const card = document.createElement('article');
+    card.className = 'cluster-card';
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.addEventListener('click', () => handleClick(item.thumb_obj));
+    const img = document.createElement('img');
+    let src = '';
+    if (item.thumb_scene){
+      src = 'thumbs/' + encodePath(item.thumb_scene);
+      img.dataset.previewKind = 'scene';
+    } else if (item.thumb_obj){
+      src = 'thumbs_obj/' + encodePath(item.thumb_obj);
+      img.dataset.previewKind = 'object';
+    }
+    if (src){
+      img.src = src;
+      img.alt = item.thumb_scene || item.thumb_obj || 'Cluster thumbnail';
+    } else {
+      img.alt = 'Missing thumbnail';
+    }
+    button.appendChild(img);
+    const meta = document.createElement('div');
+    meta.className = 'meta';
+    const title = document.createElement('div');
+    title.innerHTML = '<strong>' + (item.json_file || '') + '</strong>';
+    meta.appendChild(title);
+    const info = document.createElement('div');
+    info.textContent = 'Event #' + (item.event_index ?? '');
+    meta.appendChild(info);
+    if (item.dataIdx === null){
+      const warn = document.createElement('div');
+      warn.className = 'status';
+      warn.textContent = 'Not present in atlas dataset';
+      meta.appendChild(warn);
+    }
+    button.appendChild(meta);
+    card.appendChild(button);
+    frag.appendChild(card);
+  });
+  grid.appendChild(frag);
+})();
+<\/script>
+</body>
+</html>`;
+                win.document.open();
+                win.document.write(html);
+                win.document.close();
+            } catch (err) {
+                console.error('cluster window error', err);
+                if (win && !win.closed) {
+                    win.document.open();
+                    win.document.write("<!doctype html><title>Error</title><body style='background:#0b0d12;color:#e7eaf0;font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;padding:24px;'>Failed to load cluster view.</body>");
+                    win.document.close();
+                }
+            }
+        }
+
+        function renderCodebookSidebar(clusters) {
+            const sidebar = document.getElementById("codebookSidebar");
+            if (!sidebar) return;
+            const body = sidebar.querySelector(".sidebar-body");
+            if (!body) return;
+            if (!Array.isArray(clusters) || !clusters.length) {
+                body.innerHTML = '<div class="sidebar-empty">Codebook unavailable.</div>';
+                return;
+            }
+            const frag = document.createDocumentFragment();
+            clusters.forEach(cluster => {
+                const btn = document.createElement("button");
+                btn.type = "button";
+                btn.className = "codebook-entry";
+                btn.dataset.cluster = String(cluster.cluster_id ?? "");
+                const clusterThumb = normalizeThumbName(cluster.thumb_obj);
+                if (clusterThumb) {
+                    btn.dataset.thumbObj = clusterThumb;
+                }
+
+                const previewWrap = document.createElement("span");
+                previewWrap.className = "preview";
+                if (clusterThumb) {
+                    const info = bestPreviewForThumbObj(clusterThumb);
+                    if (info.src) {
+                        const img = document.createElement("img");
+                        img.loading = "lazy";
+                        img.decoding = "async";
+                        img.alt = `Cluster ${cluster.cluster_id ?? "?"} preview`;
+                        img.dataset.role = "cluster-preview";
+                        img.dataset.clusterPreviewSrc = info.src;
+                        img.dataset.previewKind = info.kind;
+                        img.src = info.src;
+                        previewWrap.appendChild(img);
+                    } else {
+                        const missing = document.createElement("span");
+                        missing.className = "missing-thumb";
+                        missing.textContent = "No thumb";
+                        previewWrap.appendChild(missing);
+                    }
+                } else {
+                    const missing = document.createElement("span");
+                    missing.className = "missing-thumb";
+                    missing.textContent = "No thumb";
+                    previewWrap.appendChild(missing);
+                }
+
+                const infoWrap = document.createElement("span");
+                infoWrap.className = "info";
+                const strong = document.createElement("strong");
+                strong.textContent = `${cluster.token ? `${cluster.token} • ` : ""}Cluster ${cluster.cluster_id ?? "?"}`;
+                const small = document.createElement("small");
+                small.textContent = cluster.count ? `${cluster.count} items` : "Open cluster";
+                infoWrap.appendChild(strong);
+                infoWrap.appendChild(small);
+
+                btn.appendChild(previewWrap);
+                btn.appendChild(infoWrap);
+
+                btn.addEventListener("click", () => {
+                    const w = window.open("", `codebook_cluster_${cluster.cluster_id}`, CLUSTER_WINDOW_FEATURES);
+                    if (!w) { toast("Please allow pop-ups for cluster viewer."); return; }
+                    w.document.write("<!doctype html><title>Loading…</title><body style='background:#0b0d12;color:#c9d3e5;font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;padding:24px;'>Loading cluster…</body>");
+                    w.document.close();
+                    btn.classList.add("busy");
+                    openClusterWindow(cluster, w).finally(() => btn.classList.remove("busy"));
+                });
+                frag.appendChild(btn);
+            });
+            body.innerHTML = "";
+            body.appendChild(frag);
+            refreshCodebookSidebarPreviews();
+        }
+
+        function wireCodebookChrome() {
+            const sidebar = document.getElementById("codebookSidebar");
+            const drop = document.getElementById("codebookDrop");
+            const toggle = document.getElementById("codebookToggle");
+            if (drop && sidebar) {
+                drop.addEventListener("click", () => {
+                    sidebar.classList.add("collapsed");
+                    if (toggle) toggle.focus();
+                });
+            }
+            if (toggle && sidebar) {
+                toggle.addEventListener("click", () => {
+                    sidebar.classList.remove("collapsed");
+                    sidebar.focus();
+                });
+            }
+        }
+
+        wireCodebookChrome();
+        CODEBOOK_PROMISE.then(renderCodebookSidebar).catch(() => {
+            const body = document.querySelector("#codebookSidebar .sidebar-body");
+            if (body) body.innerHTML = '<div class="sidebar-empty">Failed to load codebook.</div>';
+        });
         
         let DATA = [], CURRENT = [], CURRENT_IDX = [];
         let sortAsc = true, groupMode = "none", sortMode = "hue", thumbMode = "object", svgStyle = "default";
@@ -709,6 +1246,63 @@
         const isAbsoluteURL = (p) =>
             /^https?:\/\//i.test(p || "") || /^data:/i.test(p || "") || (p || "").startsWith("/");
 
+        const normalizeThumbName = (name) => {
+            if (!name) return "";
+            const clean = String(name).replace(/\\/g, "/").trim();
+            if (!clean) return "";
+            const parts = clean.split("/").filter(Boolean);
+            return (parts.length ? parts[parts.length - 1] : clean).trim();
+        };
+
+        const sanitizeRelativePath = (name) => {
+            if (!name) return "";
+            const clean = String(name).replace(/\\/g, "/").trim();
+            if (!clean) return "";
+            const parts = clean.split("/").filter(part => part && part !== "." && part !== "..");
+            return parts.join("/");
+        };
+
+        const encodeThumbPath = (name) =>
+            name ? name.split("/").map(part => encodeURIComponent(part)).join("/") : "";
+
+        function bestPreviewForThumbObj(thumbObjName) {
+            const normalized = normalizeThumbName(thumbObjName);
+            if (!normalized) {
+                return { src: "", kind: "none" };
+            }
+            const fallback = `thumbs_obj/${encodeThumbPath(normalized)}`;
+            const idx = THUMB_TO_INDEX.get(normalized);
+            if (typeof idx === "number" && DATA[idx]) {
+                const row = DATA[idx];
+                const scenePath = sanitizeRelativePath(row.thumb);
+                if (scenePath) {
+                    return { src: `thumbs/${encodeThumbPath(scenePath)}`, kind: "scene", fallback };
+                }
+                const objectPath = sanitizeRelativePath(row.thumb_obj);
+                if (objectPath) {
+                    return { src: `thumbs_obj/${encodeThumbPath(objectPath)}`, kind: "object", fallback };
+                }
+            }
+            return { src: fallback, kind: "object", fallback };
+        }
+
+        function refreshCodebookSidebarPreviews() {
+            const entries = document.querySelectorAll(".codebook-entry");
+            entries.forEach(entry => {
+                const thumbObj = entry.dataset.thumbObj;
+                if (!thumbObj) return;
+                const img = entry.querySelector("img[data-role='cluster-preview']");
+                if (!img) return;
+                const info = bestPreviewForThumbObj(thumbObj);
+                if (!info.src) return;
+                if (img.dataset.clusterPreviewSrc !== info.src) {
+                    img.dataset.clusterPreviewSrc = info.src;
+                    img.src = info.src;
+                }
+                img.dataset.previewKind = info.kind;
+            });
+        }
+
 
         /* ========== CSV NORMALIZATION (revised) ========== */
         function normalizeRow(r, i) {
@@ -724,7 +1318,7 @@
             );
 
             // sanitize: normalize slashes + trim
-            const clean = (s) => (typeof s === "string" ? s.replace(/\\/g, "/").trim() : "");
+            const clean = (s) => (typeof s === "string" ? sanitizeRelativePath(s) : "");
 
             return {
                 _i: i,
@@ -1171,6 +1765,20 @@
             };
         }
 
+        window.handleCodebookSelection = function(thumbName) {
+            const key = normalizeThumbName(thumbName);
+            if (!key) {
+                toast("No thumbnail specified for this cluster item.");
+                return;
+            }
+            const idx = THUMB_TO_INDEX.get(key);
+            if (typeof idx !== "number") {
+                toast("Cluster item is not present in the current atlas view.");
+                return;
+            }
+            openModalByGlobalIndex(idx);
+        };
+
         function openSVGByGlobalIndex(gi) {
             if (!allowDownload("svg")) return; // soft gate
             const it = DATA[gi];
@@ -1479,6 +2087,9 @@
                     }
                     try { dedupeByVideoClusters(); } catch {}
                     refresh(); updateHueRange();
+                    rebuildThumbIndex();
+                    refreshCodebookSidebarPreviews();
+                    if (resolveDataReady) { resolveDataReady(); resolveDataReady = null; }
                 }
             }
             Papa.parse(CSV_URL, {

--- a/tools/generate_codebook_gallery.py
+++ b/tools/generate_codebook_gallery.py
@@ -1,0 +1,239 @@
+"""Generate an HTML gallery for symbol codebook prototypes.
+
+Reads ``public/sequences/symbol_codebook_canon.json`` (or any compatible
+codebook file) and produces an HTML document that pairs each cluster with its
+``thumb.obj`` thumbnail.
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+from pathlib import Path
+from string import Template
+from typing import Iterable, List, Mapping
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--codebook",
+        type=Path,
+        default=Path("public/sequences/symbol_codebook_canon.json"),
+        help=(
+            "Path to the symbol codebook JSON file. Defaults to the canonical "
+            "codebook produced by tools/canonicalize_prototypes.py."
+        ),
+    )
+    parser.add_argument(
+        "--thumbs-dir",
+        type=Path,
+        default=Path("public/thumbs_obj"),
+        help="Directory that contains the *_obj.jpg thumbnails.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("public/codebook_gallery.html"),
+        help="Destination path for the generated HTML file.",
+    )
+    return parser.parse_args()
+
+
+def load_codebook(codebook_path: Path) -> Mapping[str, object]:
+    if not codebook_path.exists():
+        raise FileNotFoundError(
+            f"Codebook file not found: {codebook_path}. "
+            "Pass --codebook to point at the correct file."
+        )
+    with codebook_path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def normalise_clusters(raw_clusters: Iterable[Mapping[str, object]]) -> List[Mapping[str, object]]:
+    clusters: List[Mapping[str, object]] = []
+    for cluster in raw_clusters:
+        prototype = cluster.get("prototype", {})
+        clusters.append(
+            {
+                "cluster_id": cluster.get("cluster_id"),
+                "token": cluster.get("token"),
+                "count": cluster.get("count"),
+                "thumb_obj": prototype.get("thumb_obj"),
+            }
+        )
+    clusters.sort(key=lambda c: (c.get("cluster_id"), c.get("token")))
+    return clusters
+
+
+def build_html(clusters: Iterable[Mapping[str, object]], thumbs_dir: Path) -> str:
+    thumbs_rel = thumbs_dir.name
+    rows: List[str] = []
+    for cluster in clusters:
+        thumb_name = cluster.get("thumb_obj")
+        thumb_path = f"{thumbs_rel}/{thumb_name}" if thumb_name else None
+        thumb_missing = bool(thumb_name) and not (thumbs_dir / thumb_name).exists()
+
+        rows.append(
+            "    <article class=\"cluster\">\n"
+            f"      <header><h2>Cluster {html.escape(str(cluster.get('cluster_id')))}</h2></header>\n"
+            "      <div class=\"media\">\n"
+            + (
+                f"        <img src=\"{html.escape(thumb_path)}\" alt=\"Cluster {html.escape(str(cluster.get('cluster_id')))} thumbnail\">\n"
+                if thumb_path and not thumb_missing
+                else "        <div class=\"missing\">Missing thumb.obj</div>\n"
+            )
+            + "      </div>\n"
+            "      <dl class=\"meta\">\n"
+            f"        <dt>Token</dt><dd>{html.escape(str(cluster.get('token')))}</dd>\n"
+            f"        <dt>Instances</dt><dd>{html.escape(str(cluster.get('count')))}</dd>\n"
+            + (
+                f"        <dt>Thumb file</dt><dd>{html.escape(thumb_name)}</dd>\n"
+                if thumb_name
+                else ""
+            )
+            + (
+                "        <dt>Status</dt><dd class=\"warning\">Missing thumbnail file</dd>\n"
+                if thumb_missing
+                else ""
+            )
+            + "      </dl>\n"
+            "    </article>"
+        )
+
+    template = Template(
+        """<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Symbol Codebook Gallery</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: #111;
+        color: #f2f2f2;
+      }
+      body {
+        margin: 0;
+        padding: 2rem;
+        background: radial-gradient(circle at top, #1d2733, #05070b 60%);
+      }
+      h1 {
+        font-weight: 600;
+        margin-bottom: 1.5rem;
+        text-align: center;
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 1.5rem;
+      }
+      .cluster {
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        border-radius: 12px;
+        padding: 1rem;
+        background: rgba(13, 17, 23, 0.85);
+        box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+        backdrop-filter: blur(12px);
+        transition: transform 120ms ease, box-shadow 200ms ease;
+      }
+      .cluster:hover {
+        transform: translateY(-4px);
+        box-shadow: 0 20px 45px rgba(0, 0, 0, 0.4);
+      }
+      .cluster header {
+        margin-bottom: 0.75rem;
+      }
+      .cluster h2 {
+        margin: 0;
+        font-size: 1.1rem;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+      }
+      .media {
+        width: 100%;
+        aspect-ratio: 1 / 1;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 10px;
+        overflow: hidden;
+        margin-bottom: 0.75rem;
+        background: rgba(255, 255, 255, 0.04);
+      }
+      .media img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        display: block;
+      }
+      .media .missing {
+        font-size: 0.85rem;
+        color: rgba(255, 230, 150, 0.9);
+        padding: 0.5rem;
+        text-align: center;
+      }
+      .meta {
+        margin: 0;
+        display: grid;
+        grid-template-columns: auto 1fr;
+        column-gap: 0.75rem;
+        row-gap: 0.4rem;
+        font-size: 0.9rem;
+      }
+      .meta dt {
+        font-weight: 600;
+        color: rgba(255, 255, 255, 0.7);
+      }
+      .meta dd {
+        margin: 0;
+      }
+      .meta .warning {
+        color: #ffb65c;
+      }
+      footer {
+        margin-top: 2rem;
+        text-align: center;
+        font-size: 0.85rem;
+        color: rgba(255, 255, 255, 0.55);
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Symbol Codebook Gallery</h1>
+    <section class="grid">
+$rows
+    </section>
+    <footer>
+      Generated by tools/generate_codebook_gallery.py
+    </footer>
+  </body>
+</html>
+"""
+    )
+    return template.substitute(rows="\n".join(rows))
+
+
+def main() -> None:
+    args = parse_args()
+    codebook = load_codebook(args.codebook)
+
+    clusters = codebook.get("clusters")
+    if not isinstance(clusters, list):
+        raise ValueError(
+            "Unexpected codebook format: 'clusters' key is missing or not a list"
+        )
+
+    normalised = normalise_clusters(clusters)
+    html_content = build_html(normalised, args.thumbs_dir)
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(html_content, encoding="utf-8")
+    print(f"[ok] Wrote gallery → {args.output}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tools/generate_codebook_gallery.py
+++ b/tools/generate_codebook_gallery.py
@@ -15,12 +15,16 @@ from string import Template
 from typing import Iterable, List, Mapping
 
 
+DEFAULT_CANONICAL_CODEBOOK = Path("public/sequences/symbol_codebook_canon.json")
+DEFAULT_MERGED_CODEBOOK = Path("public/sequences_merge/symbol_codebook.json")
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--codebook",
         type=Path,
-        default=Path("public/sequences/symbol_codebook_canon.json"),
+        default=DEFAULT_CANONICAL_CODEBOOK,
         help=(
             "Path to the symbol codebook JSON file. Defaults to the canonical "
             "codebook produced by tools/canonicalize_prototypes.py."
@@ -42,19 +46,30 @@ def parse_args() -> argparse.Namespace:
 
 
 def load_codebook(codebook_path: Path) -> Mapping[str, object]:
-    if not codebook_path.exists():
-        raise FileNotFoundError(
-            f"Codebook file not found: {codebook_path}. "
-            "Pass --codebook to point at the correct file."
-        )
-    with codebook_path.open("r", encoding="utf-8") as fh:
-        return json.load(fh)
+    search_paths = [codebook_path]
+    if codebook_path == DEFAULT_CANONICAL_CODEBOOK:
+        search_paths.append(DEFAULT_MERGED_CODEBOOK)
+
+    for candidate in search_paths:
+        if candidate.exists():
+            with candidate.open("r", encoding="utf-8") as fh:
+                return json.load(fh)
+
+    search_str = ", ".join(str(p) for p in search_paths)
+    raise FileNotFoundError(
+        f"Codebook file not found. Looked for: {search_str}. "
+        "Pass --codebook to point at the correct file."
+    )
 
 
 def normalise_clusters(raw_clusters: Iterable[Mapping[str, object]]) -> List[Mapping[str, object]]:
     clusters: List[Mapping[str, object]] = []
     for cluster in raw_clusters:
+        if not isinstance(cluster, Mapping):
+            continue
         prototype = cluster.get("prototype", {})
+        if not isinstance(prototype, Mapping):
+            prototype = {}
         clusters.append(
             {
                 "cluster_id": cluster.get("cluster_id"),
@@ -63,11 +78,33 @@ def normalise_clusters(raw_clusters: Iterable[Mapping[str, object]]) -> List[Map
                 "thumb_obj": prototype.get("thumb_obj"),
             }
         )
-    clusters.sort(key=lambda c: (c.get("cluster_id"), c.get("token")))
+    clusters.sort(key=lambda c: (c.get("cluster_id"), str(c.get("token"))))
     return clusters
 
 
+def extract_clusters(codebook: Mapping[str, object]) -> List[Mapping[str, object]]:
+    clusters = codebook.get("clusters")
+    if isinstance(clusters, list):
+        return normalise_clusters(clusters)
+
+    legend = codebook.get("legend")
+    if isinstance(legend, Mapping):
+        converted = []
+        for token, entry in legend.items():
+            if not isinstance(entry, Mapping):
+                continue
+            cluster_payload = dict(entry)
+            cluster_payload.setdefault("token", token)
+            converted.append(cluster_payload)
+        return normalise_clusters(converted)
+
+    raise ValueError(
+        "Unexpected codebook format: expected a 'clusters' list or 'legend' mapping."
+    )
+
+
 def build_html(clusters: Iterable[Mapping[str, object]], thumbs_dir: Path) -> str:
+    thumbs_dir = thumbs_dir.resolve()
     thumbs_rel = thumbs_dir.name
     rows: List[str] = []
     for cluster in clusters:
@@ -220,13 +257,7 @@ def main() -> None:
     args = parse_args()
     codebook = load_codebook(args.codebook)
 
-    clusters = codebook.get("clusters")
-    if not isinstance(clusters, list):
-        raise ValueError(
-            "Unexpected codebook format: 'clusters' key is missing or not a list"
-        )
-
-    normalised = normalise_clusters(clusters)
+    normalised = extract_clusters(codebook)
     html_content = build_html(normalised, args.thumbs_dir)
 
     args.output.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- prefer atlas scene thumbnails for codebook sidebar entries when available and keep fallbacks for missing data
- update cluster drilldown windows to reuse the richer previews and sanitize stored thumb paths
- refresh sidebar previews after atlas data loads so the sidebar updates when new context arrives

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d92cd1c13083279b2371b59028d530