### PR TITLE
Backfill radial metadata across sequence JSON data

### DIFF
--- a/public/sequences_merge/20250328_124758000_iOS.2.json.sequence.json
+++ b/public/sequences_merge/20250328_124758000_iOS.2.json.sequence.json
@@ -327,7 +327,7 @@
     }
   },
   "symbol_seq": "HALXXCWWADAMEAPIAPKHHWWVNMAMPPFIADADEALADWAJAMAGAGANUAKADXRWNAGAGPPAHKW",
-  "symbol_seq_enhanced": "Unknown↑ Green↑ Unknown↑ Unknown↑ Blue↑ Yellow Yellow Yellow↑ Unknown↑ Unknown Unknown Yellow Unknown Unknown Yellow↑ Yellow↑ Yellow↑ Yellow↑ Pink/Magenta Blue Blue Unknown↑ Yellow↓ Yellow↓ Blue Yellow Yellow↑ Yellow↑ Unknown Green↑ Yellow↑ Yellow↓ Unknown↑ Unknown Pink/Magenta↓ Pink/Magenta↓ Unknown↑ Yellow↓ Pink/Magenta↓ Yellow↓ Unknown Yellow↓ Yellow Blue Pink/Magenta Pink/Magenta↓ Yellow↓ Yellow↓ Pink/Magenta Unknown Yellow",
+  "symbol_seq_enhanced": "Unknown↑ V0 Green↑ V0 Unknown↑ V0 Unknown↑ V0 Blue↑ V0 Yellow V0 Yellow V0 Yellow↑ V0 Unknown↑ V0 Unknown V0 Unknown V0 Yellow V0 Unknown V0 Unknown V0 Yellow↑ V0 Yellow↑ V0 Yellow↑ V0 Yellow↑ V0 Pink/Magenta V0 Blue V0 Blue V0 Unknown↑ V0 Yellow↓ V0 Yellow↓ V0 Blue V0 Yellow V0 Yellow↑ V0 Yellow↑ V0 Unknown V0 Green↑ V0 Yellow↑ V0 Yellow↓ V0 Unknown↑ V0 Unknown V0 Pink/Magenta↓ V0 Pink/Magenta↓ V0 Unknown↑ V0 Yellow↓ V0 Pink/Magenta↓ V0 Yellow↓ V0 Unknown V0 Yellow↓ V0 Yellow V0 Blue V0 Pink/Magenta V0 Pink/Magenta↓ V0 Yellow↓ V0 Yellow↓ V0 Pink/Magenta V0 Unknown V0 Yellow V0",
   "binary_seq": "000010000101011100101000000010000011001001001100110",
   "v_threshold": 0.474,
   "events": [
@@ -341,7 +341,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 0,
-      "thumb_obj": "20250328_124758000_iOS.2_e000_000300_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e000_000300_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 1,
@@ -353,7 +361,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 1,
-      "thumb_obj": "20250328_124758000_iOS.2_e001_001050_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e001_001050_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 2,
@@ -365,7 +381,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 2,
-      "thumb_obj": "20250328_124758000_iOS.2_e002_001750_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e002_001750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 3,
@@ -377,7 +401,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 2,
-      "thumb_obj": "20250328_124758000_iOS.2_e003_002300_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e003_002300_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 4,
@@ -389,7 +421,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250328_124758000_iOS.2_e004_002900_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e004_002900_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 5,
@@ -401,7 +441,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "20250328_124758000_iOS.2_e005_003650_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e005_003650_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 6,
@@ -413,7 +460,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "20250328_124758000_iOS.2_e006_004550_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e006_004550_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 7,
@@ -425,7 +479,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 5,
-      "thumb_obj": "20250328_124758000_iOS.2_e007_005350_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e007_005350_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 8,
@@ -437,7 +499,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 7,
-      "thumb_obj": "20250328_124758000_iOS.2_e008_006050_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e008_006050_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 9,
@@ -449,7 +519,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "20250328_124758000_iOS.2_e009_006700_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e009_006700_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 10,
@@ -461,7 +538,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 9,
-      "thumb_obj": "20250328_124758000_iOS.2_e010_007350_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e010_007350_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 11,
@@ -473,7 +557,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "20250328_124758000_iOS.2_e011_007949_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e011_007949_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 12,
@@ -485,7 +576,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 9,
-      "thumb_obj": "20250328_124758000_iOS.2_e012_008550_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e012_008550_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 13,
@@ -497,7 +595,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "20250328_124758000_iOS.2_e013_009200_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e013_009200_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 14,
@@ -509,7 +614,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "20250328_124758000_iOS.2_e014_009850_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e014_009850_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 15,
@@ -521,7 +634,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "20250328_124758000_iOS.2_e015_010600_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e015_010600_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 16,
@@ -533,7 +654,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "20250328_124758000_iOS.2_e016_011300_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e016_011300_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 17,
@@ -545,7 +674,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "20250328_124758000_iOS.2_e017_012000_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e017_012000_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 18,
@@ -557,7 +694,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "20250328_124758000_iOS.2_e018_012700_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e018_012700_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 19,
@@ -569,7 +713,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "20250328_124758000_iOS.2_e019_013300_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e019_013300_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 20,
@@ -581,7 +732,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "20250328_124758000_iOS.2_e020_013899_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e020_013899_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 21,
@@ -593,7 +751,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 7,
-      "thumb_obj": "20250328_124758000_iOS.2_e021_014550_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e021_014550_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 22,
@@ -605,7 +771,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "20250328_124758000_iOS.2_e022_015200_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e022_015200_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 23,
@@ -617,7 +791,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "20250328_124758000_iOS.2_e023_015750_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e023_015750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 24,
@@ -629,7 +811,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250328_124758000_iOS.2_e024_016300_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e024_016300_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 25,
@@ -641,7 +830,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "20250328_124758000_iOS.2_e025_016850_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e025_016850_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 26,
@@ -653,7 +849,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 5,
-      "thumb_obj": "20250328_124758000_iOS.2_e026_017350_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e026_017350_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 27,
@@ -665,7 +869,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 5,
-      "thumb_obj": "20250328_124758000_iOS.2_e027_017850_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e027_017850_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 28,
@@ -677,7 +889,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "20250328_124758000_iOS.2_e028_018350_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e028_018350_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 29,
@@ -689,7 +908,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 1,
-      "thumb_obj": "20250328_124758000_iOS.2_e029_018850_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e029_018850_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 30,
@@ -701,7 +928,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 5,
-      "thumb_obj": "20250328_124758000_iOS.2_e030_019400_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e030_019400_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 31,
@@ -713,7 +948,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "20250328_124758000_iOS.2_e031_020100_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e031_020100_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 32,
@@ -725,7 +968,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 24,
-      "thumb_obj": "20250328_124758000_iOS.2_e032_020750_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e032_020750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 33,
@@ -737,7 +988,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 7,
-      "thumb_obj": "20250328_124758000_iOS.2_e033_021250_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e033_021250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 34,
@@ -749,7 +1007,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 26,
-      "thumb_obj": "20250328_124758000_iOS.2_e034_021750_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e034_021750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 35,
@@ -761,7 +1027,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 26,
-      "thumb_obj": "20250328_124758000_iOS.2_e035_022300_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e035_022300_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 36,
@@ -773,7 +1047,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 27,
-      "thumb_obj": "20250328_124758000_iOS.2_e036_022900_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e036_022900_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 37,
@@ -785,7 +1067,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "20250328_124758000_iOS.2_e037_023500_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e037_023500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 38,
@@ -797,7 +1087,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 29,
-      "thumb_obj": "20250328_124758000_iOS.2_e038_024050_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e038_024050_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 39,
@@ -809,7 +1107,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 5,
-      "thumb_obj": "20250328_124758000_iOS.2_e039_024600_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e039_024600_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 40,
@@ -821,7 +1127,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 2,
-      "thumb_obj": "20250328_124758000_iOS.2_e040_025250_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e040_025250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 41,
@@ -833,7 +1146,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "20250328_124758000_iOS.2_e041_025800_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e041_025800_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 42,
@@ -845,7 +1166,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "20250328_124758000_iOS.2_e042_026300_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e042_026300_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 43,
@@ -857,7 +1185,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "20250328_124758000_iOS.2_e043_026900_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e043_026900_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 44,
@@ -869,7 +1204,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 26,
-      "thumb_obj": "20250328_124758000_iOS.2_e044_027500_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e044_027500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 45,
@@ -881,7 +1223,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 26,
-      "thumb_obj": "20250328_124758000_iOS.2_e045_028150_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e045_028150_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 46,
@@ -893,7 +1243,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "20250328_124758000_iOS.2_e046_028850_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e046_028850_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 47,
@@ -905,7 +1263,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "20250328_124758000_iOS.2_e047_029500_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e047_029500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 48,
@@ -917,7 +1283,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 31,
-      "thumb_obj": "20250328_124758000_iOS.2_e048_030150_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e048_030150_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 49,
@@ -929,7 +1302,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "20250328_124758000_iOS.2_e049_030850_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e049_030850_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 50,
@@ -941,11 +1321,18 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "20250328_124758000_iOS.2_e050_031750_obj.jpg"
+      "thumb_obj": "20250328_124758000_iOS.2_e050_031750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     }
   ],
   "cycles": [
-    "Unknown↑ Green↑ Unknown↑ Unknown↑ Blue↑ Yellow Yellow Yellow↑ Unknown↑ Unknown Unknown Yellow Unknown Unknown Yellow↑ Yellow↑ Yellow↑ Yellow↑ Pink/Magenta Blue Blue Unknown↑ Yellow↓ Yellow↓ Blue Yellow Yellow↑ Yellow↑ Unknown Green↑ Yellow↑ Yellow↓ Unknown↑ Unknown Pink/Magenta↓ Pink/Magenta↓ Unknown↑ Yellow↓ Pink/Magenta↓ Yellow↓ Unknown Yellow↓ Yellow Blue Pink/Magenta Pink/Magenta↓ Yellow↓ Yellow↓ Pink/Magenta Unknown Yellow"
+    "Unknown↑ V0 Green↑ V0 Unknown↑ V0 Unknown↑ V0 Blue↑ V0 Yellow V0 Yellow V0 Yellow↑ V0 Unknown↑ V0 Unknown V0 Unknown V0 Yellow V0 Unknown V0 Unknown V0 Yellow↑ V0 Yellow↑ V0 Yellow↑ V0 Yellow↑ V0 Pink/Magenta V0 Blue V0 Blue V0 Unknown↑ V0 Yellow↓ V0 Yellow↓ V0 Blue V0 Yellow V0 Yellow↑ V0 Yellow↑ V0 Unknown V0 Green↑ V0 Yellow↑ V0 Yellow↓ V0 Unknown↑ V0 Unknown V0 Pink/Magenta↓ V0 Pink/Magenta↓ V0 Unknown↑ V0 Yellow↓ V0 Pink/Magenta↓ V0 Yellow↓ V0 Unknown V0 Yellow↓ V0 Yellow V0 Blue V0 Pink/Magenta V0 Pink/Magenta↓ V0 Yellow↓ V0 Yellow↓ V0 Pink/Magenta V0 Unknown V0 Yellow V0"
   ],
   "clustering": {
     "eps": 0.34,

--- a/public/sequences_merge/20250812_034218000_iOS.json.sequence.json
+++ b/public/sequences_merge/20250812_034218000_iOS.json.sequence.json
@@ -361,7 +361,7 @@
     }
   },
   "symbol_seq": "ATFALAEAMOCALBACAEALGHCEGAKJFCFAOAPATARABAYQAXARZCALADAYXARZCALNAY",
-  "symbol_seq_enhanced": "Unknown↑ Blue Green↓ Blue↓ Unknown Blue↓ Blue↑ Green↑ Blue↓ Pink/Magenta↑ Blue↑ Green↓ Blue↓ Yellow↓ Blue Unknown Blue↓ Pink/Magenta Blue Blue Blue↑ Blue↓ Green↓ Unknown Unknown Unknown Pink/Magenta↓ Green↑ Unknown Blue↓ Blue Unknown Unknown↑ Blue↑ Green↑ Yellow↑ Green↑ Blue Unknown Unknown↑ Blue↑ Green↑ Blue↑ Green↑",
+  "symbol_seq_enhanced": "Unknown↑ V0 Blue V0 Green↓ V0 Blue↓ V0 Unknown V0 Blue↓ V0 Blue↑ V0 Green↑ V0 Blue↓ V0 Pink/Magenta↑ V0 Blue↑ V0 Green↓ V0 Blue↓ V0 Yellow↓ V0 Blue V0 Unknown V0 Blue↓ V0 Pink/Magenta V0 Blue V0 Blue V0 Blue↑ V0 Blue↓ V0 Green↓ V0 Unknown V0 Unknown V0 Unknown V0 Pink/Magenta↓ V0 Green↑ V0 Unknown V0 Blue↓ V0 Blue V0 Unknown V0 Unknown↑ V0 Blue↑ V0 Green↑ V0 Yellow↑ V0 Green↑ V0 Blue V0 Unknown V0 Unknown↑ V0 Blue↑ V0 Green↑ V0 Blue↑ V0 Green↑ V0",
   "binary_seq": "00000000100010001101110010101110010000101000",
   "v_threshold": 0.49933333333333335,
   "events": [
@@ -375,7 +375,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 32,
-      "thumb_obj": "20250812_034218000_iOS_e000_002650_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS_e000_002650_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 1,
@@ -387,7 +395,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250812_034218000_iOS_e001_003900_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS_e001_003900_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 2,
@@ -399,7 +414,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 1,
-      "thumb_obj": "20250812_034218000_iOS_e002_005200_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS_e002_005200_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 3,
@@ -411,7 +434,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 34,
-      "thumb_obj": "20250812_034218000_iOS_e003_006600_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS_e003_006600_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 4,
@@ -423,7 +454,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 7,
-      "thumb_obj": "20250812_034218000_iOS_e004_010400_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS_e004_010400_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 5,
@@ -435,7 +473,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "20250812_034218000_iOS_e005_010800_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS_e005_010800_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 6,
@@ -447,7 +493,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250812_034218000_iOS_e006_011149_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS_e006_011149_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 7,
@@ -459,7 +513,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 1,
-      "thumb_obj": "20250812_034218000_iOS_e007_012050_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS_e007_012050_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 8,
@@ -471,7 +533,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250812_034218000_iOS_e008_013100_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS_e008_013100_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 9,
@@ -483,7 +553,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 38,
-      "thumb_obj": "20250812_034218000_iOS_e009_013500_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS_e009_013500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 10,
@@ -495,7 +573,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 34,
-      "thumb_obj": "20250812_034218000_iOS_e010_014649_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS_e010_014649_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 11,
@@ -507,7 +593,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 1,
-      "thumb_obj": "20250812_034218000_iOS_e011_018900_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS_e011_018900_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 12,
@@ -519,7 +613,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250812_034218000_iOS_e012_020100_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS_e012_020100_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 13,
@@ -531,7 +633,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "20250812_034218000_iOS_e013_021250_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS_e013_021250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 14,
@@ -543,7 +653,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250812_034218000_iOS_e014_021650_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS_e014_021650_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 15,
@@ -555,7 +672,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "20250812_034218000_iOS_e015_022550_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS_e015_022550_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 16,
@@ -567,7 +691,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250812_034218000_iOS_e016_022750_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS_e016_022750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 17,
@@ -579,7 +711,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 29,
-      "thumb_obj": "20250812_034218000_iOS_e017_023950_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS_e017_023950_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 18,
@@ -591,7 +730,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "20250812_034218000_iOS_e018_025450_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS_e018_025450_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 19,
@@ -603,7 +749,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250812_034218000_iOS_e019_028250_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS_e019_028250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 20,
@@ -615,7 +768,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250812_034218000_iOS_e020_029500_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS_e020_029500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 21,
@@ -627,7 +788,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250812_034218000_iOS_e021_030600_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS_e021_030600_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 22,
@@ -639,7 +808,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 41,
-      "thumb_obj": "20250812_034218000_iOS_e022_031000_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS_e022_031000_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 23,
@@ -651,7 +828,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 9,
-      "thumb_obj": "20250812_034218000_iOS_e023_032150_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS_e023_032150_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 24,
@@ -663,7 +847,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 32,
-      "thumb_obj": "20250812_034218000_iOS_e024_033300_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS_e024_033300_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 25,
@@ -675,7 +866,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 42,
-      "thumb_obj": "20250812_034218000_iOS_e025_034849_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS_e025_034849_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 26,
@@ -687,7 +885,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 44,
-      "thumb_obj": "20250812_034218000_iOS_e026_036050_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS_e026_036050_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 27,
@@ -699,7 +905,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 45,
-      "thumb_obj": "20250812_034218000_iOS_e027_038850_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS_e027_038850_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 28,
@@ -711,7 +925,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "20250812_034218000_iOS_e028_040350_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS_e028_040350_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 29,
@@ -723,7 +944,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250812_034218000_iOS_e029_041450_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS_e029_041450_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 30,
@@ -735,7 +964,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 2,
-      "thumb_obj": "20250812_034218000_iOS_e030_044150_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS_e030_044150_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 31,
@@ -747,7 +983,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 42,
-      "thumb_obj": "20250812_034218000_iOS_e031_045700_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS_e031_045700_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 32,
@@ -759,7 +1002,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 49,
-      "thumb_obj": "20250812_034218000_iOS_e032_046100_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS_e032_046100_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 33,
@@ -771,7 +1022,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250812_034218000_iOS_e033_046950_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS_e033_046950_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 34,
@@ -783,7 +1042,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 1,
-      "thumb_obj": "20250812_034218000_iOS_e034_047150_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS_e034_047150_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 35,
@@ -795,7 +1062,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 5,
-      "thumb_obj": "20250812_034218000_iOS_e035_048400_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS_e035_048400_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 36,
@@ -807,7 +1082,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 45,
-      "thumb_obj": "20250812_034218000_iOS_e036_050000_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS_e036_050000_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 37,
@@ -819,7 +1102,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 2,
-      "thumb_obj": "20250812_034218000_iOS_e037_044200_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS_e037_044200_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 38,
@@ -831,7 +1121,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 42,
-      "thumb_obj": "20250812_034218000_iOS_e038_045700_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS_e038_045700_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 39,
@@ -843,7 +1140,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 49,
-      "thumb_obj": "20250812_034218000_iOS_e039_046150_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS_e039_046150_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 40,
@@ -855,7 +1160,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250812_034218000_iOS_e040_047000_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS_e040_047000_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 41,
@@ -867,7 +1180,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 1,
-      "thumb_obj": "20250812_034218000_iOS_e041_047200_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS_e041_047200_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 42,
@@ -879,7 +1200,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "20250812_034218000_iOS_e042_048500_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS_e042_048500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 43,
@@ -891,17 +1220,25 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 45,
-      "thumb_obj": "20250812_034218000_iOS_e043_050000_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS_e043_050000_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     }
   ],
   "cycles": [
-    "Unknown↑ Blue Green↓ Blue↓",
-    "Unknown Blue↓ Blue↑ Green↑ Blue↓ Pink/Magenta↑ Blue↑",
-    "Green↓ Blue↓ Yellow↓ Blue Unknown Blue↓ Pink/Magenta Blue",
-    "Blue Blue↑ Blue↓ Green↓ Unknown Unknown Unknown Pink/Magenta↓",
-    "Green↑ Unknown Blue↓",
-    "Blue Unknown Unknown↑ Blue↑ Green↑ Yellow↑ Green↑",
-    "Blue Unknown Unknown↑ Blue↑ Green↑ Blue↑ Green↑"
+    "Unknown↑ V0 Blue V0 Green↓ V0 Blue↓ V0",
+    "Unknown V0 Blue↓ V0 Blue↑ V0 Green↑ V0 Blue↓ V0 Pink/Magenta↑ V0 Blue↑ V0",
+    "Green↓ V0 Blue↓ V0 Yellow↓ V0 Blue V0 Unknown V0 Blue↓ V0 Pink/Magenta V0 Blue V0",
+    "Blue V0 Blue↑ V0 Blue↓ V0 Green↓ V0 Unknown V0 Unknown V0 Unknown V0 Pink/Magenta↓ V0",
+    "Green↑ V0 Unknown V0 Blue↓ V0",
+    "Blue V0 Unknown V0 Unknown↑ V0 Blue↑ V0 Green↑ V0 Yellow↑ V0 Green↑ V0",
+    "Blue V0 Unknown V0 Unknown↑ V0 Blue↑ V0 Green↑ V0 Blue↑ V0 Green↑ V0"
   ],
   "clustering": {
     "eps": 0.34,

--- a/public/sequences_merge/20250812_034218000_iOS2.5.json.sequence.json
+++ b/public/sequences_merge/20250812_034218000_iOS2.5.json.sequence.json
@@ -327,7 +327,7 @@
     }
   },
   "symbol_seq": "GCAXDBAAOXAOBAVBALAFBMYGCEAJAFBGBQUGACAYBCEFDCVGAOBAUGXAMAABCGBPANAW_FCXDAV",
-  "symbol_seq_enhanced": "Blue Blue Unknown Blue Blue Blue Green↑ Unknown↑ Green↓ Blue Unknown↑ Blue↓ Green↓ Pink/Magenta↓ Blue↓ Blue Unknown↓ Blue Blue Unknown Green↑ Pink/Magenta Blue Blue Blue↑ Yellow↓ Blue Pink/Magenta Green↑ Blue↑ Blue Unknown Blue Blue↓ Blue↑ Pink/Magenta Blue Green↓ Blue Green↓ Blue↓ Blue Unknown Blue Pink/Magenta Blue Blue Unknown↓ Unknown Unknown↓ Blue↑ Blue↓ Blue Blue Blue Unknown↓",
+  "symbol_seq_enhanced": "Blue V0 Blue V0 Unknown V0 Blue V0 Blue V0 Blue V0 Green↑ V0 Unknown↑ V0 Green↓ V0 Blue V0 Unknown↑ V0 Blue↓ V0 Green↓ V0 Pink/Magenta↓ V0 Blue↓ V0 Blue V0 Unknown↓ V0 Blue V0 Blue V0 Unknown V0 Green↑ V0 Pink/Magenta V0 Blue V0 Blue V0 Blue↑ V0 Yellow↓ V0 Blue V0 Pink/Magenta V0 Green↑ V0 Blue↑ V0 Blue V0 Unknown V0 Blue V0 Blue↓ V0 Blue↑ V0 Pink/Magenta V0 Blue V0 Green↓ V0 Blue V0 Green↓ V0 Blue↓ V0 Blue V0 Unknown V0 Blue V0 Pink/Magenta V0 Blue V0 Blue V0 Unknown↓ V0 Unknown V0 Unknown↓ V0 Blue↑ V0 Blue↓ V0 Blue V0 Blue V0 Blue V0 Unknown↓ V0",
   "binary_seq": "01001100010000100000001100010100101000100001111000000010",
   "v_threshold": 0.503,
   "events": [
@@ -341,7 +341,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250812_034218000_iOS2.5_e000_000200_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e000_000200_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 1,
@@ -353,7 +360,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250812_034218000_iOS2.5_e001_000550_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e001_000550_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 2,
@@ -365,7 +379,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 50,
-      "thumb_obj": "20250812_034218000_iOS2.5_e002_000950_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e002_000950_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 3,
@@ -377,7 +398,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250812_034218000_iOS2.5_e003_001800_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e003_001800_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 4,
@@ -389,7 +417,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250812_034218000_iOS2.5_e004_003800_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e004_003800_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 5,
@@ -401,7 +436,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250812_034218000_iOS2.5_e005_004650_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e005_004650_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 6,
@@ -413,7 +455,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 41,
-      "thumb_obj": "20250812_034218000_iOS2.5_e006_006000_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e006_006000_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 7,
@@ -425,7 +475,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 2,
-      "thumb_obj": "20250812_034218000_iOS2.5_e007_007350_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e007_007350_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 8,
@@ -437,7 +495,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 41,
-      "thumb_obj": "20250812_034218000_iOS2.5_e008_008750_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e008_008750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 9,
@@ -449,7 +515,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250812_034218000_iOS2.5_e009_009450_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e009_009450_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 10,
@@ -461,7 +534,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 53,
-      "thumb_obj": "20250812_034218000_iOS2.5_e010_010350_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e010_010350_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 11,
@@ -473,7 +554,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250812_034218000_iOS2.5_e011_010700_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e011_010700_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 12,
@@ -485,7 +574,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 1,
-      "thumb_obj": "20250812_034218000_iOS2.5_e012_011450_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e012_011450_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 13,
@@ -497,7 +594,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 54,
-      "thumb_obj": "20250812_034218000_iOS2.5_e013_012649_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e013_012649_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 14,
@@ -509,7 +614,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250812_034218000_iOS2.5_e014_012950_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e014_012950_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 15,
@@ -521,7 +634,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "20250812_034218000_iOS2.5_e015_015350_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e015_015350_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 16,
@@ -533,7 +653,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "20250812_034218000_iOS2.5_e016_015649_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e016_015649_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 17,
@@ -545,7 +673,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250812_034218000_iOS2.5_e017_016450_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e017_016450_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 18,
@@ -557,7 +692,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250812_034218000_iOS2.5_e018_016850_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e018_016850_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 19,
@@ -569,7 +711,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "20250812_034218000_iOS2.5_e019_018050_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e019_018050_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 20,
@@ -581,7 +730,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 24,
-      "thumb_obj": "20250812_034218000_iOS2.5_e020_018350_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e020_018350_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 22,
@@ -593,7 +750,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 54,
-      "thumb_obj": "20250812_034218000_iOS2.5_e022_019550_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e022_019550_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 23,
@@ -605,7 +769,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250812_034218000_iOS2.5_e023_020350_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e023_020350_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 24,
@@ -617,7 +788,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250812_034218000_iOS2.5_e024_021150_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e024_021150_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 25,
@@ -629,7 +807,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 52,
-      "thumb_obj": "20250812_034218000_iOS2.5_e025_021450_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e025_021450_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 26,
@@ -641,7 +827,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "20250812_034218000_iOS2.5_e026_022299_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e026_022299_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 27,
@@ -653,7 +847,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250812_034218000_iOS2.5_e027_022750_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e027_022750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 28,
@@ -665,7 +866,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 38,
-      "thumb_obj": "20250812_034218000_iOS2.5_e028_023450_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e028_023450_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 29,
@@ -677,7 +885,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 45,
-      "thumb_obj": "20250812_034218000_iOS2.5_e029_023550_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e029_023550_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 30,
@@ -689,7 +905,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250812_034218000_iOS2.5_e030_024750_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e030_024750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 31,
@@ -701,7 +925,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250812_034218000_iOS2.5_e031_024950_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e031_024950_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 32,
@@ -713,7 +944,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "20250812_034218000_iOS2.5_e032_026150_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e032_026150_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 33,
@@ -725,7 +963,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250812_034218000_iOS2.5_e033_026250_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e033_026250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 34,
@@ -737,7 +982,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250812_034218000_iOS2.5_e034_026900_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e034_026900_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 35,
@@ -749,7 +1002,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250812_034218000_iOS2.5_e035_027950_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e035_027950_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 36,
@@ -761,7 +1022,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "20250812_034218000_iOS2.5_e036_028150_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e036_028150_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 37,
@@ -773,7 +1041,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250812_034218000_iOS2.5_e037_028450_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e037_028450_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 38,
@@ -785,7 +1060,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 41,
-      "thumb_obj": "20250812_034218000_iOS2.5_e038_029250_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e038_029250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 39,
@@ -797,7 +1080,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250812_034218000_iOS2.5_e039_030050_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e039_030050_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 40,
@@ -809,7 +1099,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 56,
-      "thumb_obj": "20250812_034218000_iOS2.5_e040_030450_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e040_030450_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 41,
@@ -821,7 +1119,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250812_034218000_iOS2.5_e041_030850_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e041_030850_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 42,
@@ -833,7 +1139,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 2,
-      "thumb_obj": "20250812_034218000_iOS2.5_e042_031650_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e042_031650_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 44,
@@ -845,7 +1158,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 7,
-      "thumb_obj": "20250812_034218000_iOS2.5_e044_033000_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e044_033000_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 45,
@@ -857,7 +1177,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250812_034218000_iOS2.5_e045_033600_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e045_033600_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 46,
@@ -869,7 +1196,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 44,
-      "thumb_obj": "20250812_034218000_iOS2.5_e046_034300_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e046_034300_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 47,
@@ -881,7 +1215,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250812_034218000_iOS2.5_e047_034950_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e047_034950_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 48,
@@ -893,7 +1234,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250812_034218000_iOS2.5_e048_035650_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e048_035650_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 49,
@@ -905,7 +1253,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 25,
-      "thumb_obj": "20250812_034218000_iOS2.5_e049_037050_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e049_037050_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 50,
@@ -917,7 +1273,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 27,
-      "thumb_obj": "20250812_034218000_iOS2.5_e050_038250_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e050_038250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 51,
@@ -929,7 +1292,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 58,
-      "thumb_obj": "20250812_034218000_iOS2.5_e051_038650_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e051_038650_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 52,
@@ -941,7 +1312,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": -1,
-      "thumb_obj": "20250812_034218000_iOS2.5_e052_039849_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e052_039849_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 53,
@@ -953,7 +1332,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250812_034218000_iOS2.5_e053_040950_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e053_040950_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 54,
@@ -965,7 +1352,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250812_034218000_iOS2.5_e054_041349_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e054_041349_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 55,
@@ -977,7 +1371,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 2,
-      "thumb_obj": "20250812_034218000_iOS2.5_e055_042450_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e055_042450_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 56,
@@ -989,7 +1390,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250812_034218000_iOS2.5_e056_043650_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e056_043650_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 57,
@@ -1001,12 +1409,20 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 53,
-      "thumb_obj": "20250812_034218000_iOS2.5_e057_043950_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.5_e057_043950_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     }
   ],
   "cycles": [
-    "Blue Blue Unknown Blue Blue Blue Green↑ Unknown↑ Green↓ Blue Unknown↑ Blue↓ Green↓ Pink/Magenta↓ Blue↓",
-    "Blue Unknown↓ Blue Blue Unknown Green↑ Pink/Magenta Blue Blue Blue↑ Yellow↓ Blue Pink/Magenta Green↑ Blue↑ Blue Unknown Blue Blue↓ Blue↑ Pink/Magenta Blue Green↓ Blue Green↓ Blue↓ Blue Unknown Blue Pink/Magenta Blue Blue Unknown↓ Unknown Unknown↓ Blue↑ Blue↓ Blue Blue Blue Unknown↓"
+    "Blue V0 Blue V0 Unknown V0 Blue V0 Blue V0 Blue V0 Green↑ V0 Unknown↑ V0 Green↓ V0 Blue V0 Unknown↑ V0 Blue↓ V0 Green↓ V0 Pink/Magenta↓ V0 Blue↓ V0",
+    "Blue V0 Unknown↓ V0 Blue V0 Blue V0 Unknown V0 Green↑ V0 Pink/Magenta V0 Blue V0 Blue V0 Blue↑ V0 Yellow↓ V0 Blue V0 Pink/Magenta V0 Green↑ V0 Blue↑ V0 Blue V0 Unknown V0 Blue V0 Blue↓ V0 Blue↑ V0 Pink/Magenta V0 Blue V0 Green↓ V0 Blue V0 Green↓ V0 Blue↓ V0 Blue V0 Unknown V0 Blue V0 Pink/Magenta V0 Blue V0 Blue V0 Unknown↓ V0 Unknown V0 Unknown↓ V0 Blue↑ V0 Blue↓ V0 Blue V0 Blue V0 Blue V0 Unknown↓ V0"
   ],
   "clustering": {
     "eps": 0.34,

--- a/public/sequences_merge/20250812_034218000_iOS2.6.json.sequence.json
+++ b/public/sequences_merge/20250812_034218000_iOS2.6.json.sequence.json
@@ -395,7 +395,7 @@
     }
   },
   "symbol_seq": "ANOHAALEGBHAFAAGGAKUCGACBGGFAAGAJAVGBCZBBAMAMACACBBPANANBDAAFFAPAMARARACCALFADBLIOARFOTOBFAOAOAWATCAXD",
-  "symbol_seq_enhanced": "Blue Blue Blue↓ Yellow Blue Green↓ Unknown Blue↓ Blue Yellow↓ Pink/Magenta Blue↓ Blue Blue↓ Blue Pink/Magenta Yellow↓ Blue Blue Pink/Magenta Blue↑ Blue Blue Blue Blue Pink/Magenta↓ Green↑ Unknown Blue Blue↓ Blue Unknown Blue Blue Unknown Unknown Pink/Magenta Pink/Magenta Blue Unknown↓ Unknown Unknown Unknown Blue Blue↓ Blue↓ Blue↓ Unknown↓ Unknown↑ Unknown Unknown Blue Blue↓ Blue↑ Green↑ Blue↓ Yellow↑ Unknown Yellow↑ Blue Unknown Blue↑ Blue Pink/Magenta Blue Blue Blue Green↑ Green↑ Unknown Unknown↑ Blue Unknown↓ Blue",
+  "symbol_seq_enhanced": "Blue V0 Blue V0 Blue↓ V0 Yellow V0 Blue V0 Green↓ V0 Unknown V0 Blue↓ V0 Blue V0 Yellow↓ V0 Pink/Magenta V0 Blue↓ V0 Blue V0 Blue↓ V0 Blue V0 Pink/Magenta V0 Yellow↓ V0 Blue V0 Blue V0 Pink/Magenta V0 Blue↑ V0 Blue V0 Blue V0 Blue V0 Blue V0 Pink/Magenta↓ V0 Green↑ V0 Unknown V0 Blue V0 Blue↓ V0 Blue V0 Unknown V0 Blue V0 Blue V0 Unknown V0 Unknown V0 Pink/Magenta V0 Pink/Magenta V0 Blue V0 Unknown↓ V0 Unknown V0 Unknown V0 Unknown V0 Blue V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Unknown↓ V0 Unknown↑ V0 Unknown V0 Unknown V0 Blue V0 Blue↓ V0 Blue↑ V0 Green↑ V0 Blue↓ V0 Yellow↑ V0 Unknown V0 Yellow↑ V0 Blue V0 Unknown V0 Blue↑ V0 Blue V0 Pink/Magenta V0 Blue V0 Blue V0 Blue V0 Green↑ V0 Green↑ V0 Unknown V0 Unknown↑ V0 Blue V0 Unknown↓ V0 Blue V0",
   "binary_seq": "10001000000011010100011110000000000011100001000000010100000000100110000001",
   "v_threshold": 0.5640000000000001,
   "events": [
@@ -409,7 +409,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250812_034218000_iOS2.6_e000_001700_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e000_001700_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 1,
@@ -421,7 +428,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "20250812_034218000_iOS2.6_e001_003450_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e001_003450_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 2,
@@ -433,7 +447,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "20250812_034218000_iOS2.6_e002_004050_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e002_004050_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 3,
@@ -445,7 +467,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "20250812_034218000_iOS2.6_e003_004650_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e003_004650_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 4,
@@ -457,7 +486,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250812_034218000_iOS2.6_e004_004800_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e004_004800_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 5,
@@ -469,7 +505,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 1,
-      "thumb_obj": "20250812_034218000_iOS2.6_e005_005000_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e005_005000_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 6,
@@ -481,7 +525,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "20250812_034218000_iOS2.6_e006_005550_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e006_005550_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 7,
@@ -493,7 +544,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250812_034218000_iOS2.6_e007_006100_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e007_006100_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 8,
@@ -505,7 +564,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250812_034218000_iOS2.6_e008_006750_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e008_006750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 9,
@@ -517,7 +583,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "20250812_034218000_iOS2.6_e009_007350_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e009_007350_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 10,
@@ -529,7 +603,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 54,
-      "thumb_obj": "20250812_034218000_iOS2.6_e010_007500_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e010_007500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 11,
@@ -541,7 +622,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250812_034218000_iOS2.6_e011_007650_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e011_007650_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 12,
@@ -553,7 +642,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250812_034218000_iOS2.6_e012_008250_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e012_008250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 13,
@@ -565,7 +661,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250812_034218000_iOS2.6_e013_008850_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e013_008850_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 14,
@@ -577,7 +681,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250812_034218000_iOS2.6_e014_009400_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e014_009400_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 15,
@@ -589,7 +700,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 29,
-      "thumb_obj": "20250812_034218000_iOS2.6_e015_010000_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e015_010000_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 16,
@@ -601,7 +719,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "20250812_034218000_iOS2.6_e016_010200_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e016_010200_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 17,
@@ -613,7 +739,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250812_034218000_iOS2.6_e017_010400_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e017_010400_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 18,
@@ -625,7 +758,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250812_034218000_iOS2.6_e018_010600_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e018_010600_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 19,
@@ -637,7 +777,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 38,
-      "thumb_obj": "20250812_034218000_iOS2.6_e019_011649_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e019_011649_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 20,
@@ -649,7 +796,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250812_034218000_iOS2.6_e020_012700_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e020_012700_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 21,
@@ -661,7 +816,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250812_034218000_iOS2.6_e021_012900_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e021_012900_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 22,
@@ -673,7 +835,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250812_034218000_iOS2.6_e022_013600_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e022_013600_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 23,
@@ -685,7 +854,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250812_034218000_iOS2.6_e023_014250_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e023_014250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 24,
@@ -697,7 +873,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250812_034218000_iOS2.6_e024_014800_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e024_014800_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 25,
@@ -709,7 +892,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 26,
-      "thumb_obj": "20250812_034218000_iOS2.6_e025_015400_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e025_015400_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 26,
@@ -721,7 +912,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 24,
-      "thumb_obj": "20250812_034218000_iOS2.6_e026_015550_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e026_015550_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 27,
@@ -733,7 +932,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 53,
-      "thumb_obj": "20250812_034218000_iOS2.6_e027_015700_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e027_015700_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 28,
@@ -745,7 +951,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250812_034218000_iOS2.6_e028_016300_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e028_016300_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 29,
@@ -757,7 +970,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250812_034218000_iOS2.6_e029_016900_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e029_016900_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 30,
@@ -769,7 +990,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250812_034218000_iOS2.6_e030_017500_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e030_017500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 31,
@@ -781,7 +1009,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 49,
-      "thumb_obj": "20250812_034218000_iOS2.6_e031_018100_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e031_018100_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 32,
@@ -793,7 +1028,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250812_034218000_iOS2.6_e032_018950_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e032_018950_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 33,
@@ -805,7 +1047,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250812_034218000_iOS2.6_e033_019750_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e033_019750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 34,
@@ -817,7 +1066,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 7,
-      "thumb_obj": "20250812_034218000_iOS2.6_e034_020450_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e034_020450_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 35,
@@ -829,7 +1085,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 7,
-      "thumb_obj": "20250812_034218000_iOS2.6_e035_021200_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e035_021200_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 36,
@@ -841,7 +1104,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 38,
-      "thumb_obj": "20250812_034218000_iOS2.6_e036_021800_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e036_021800_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 37,
@@ -853,7 +1123,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 38,
-      "thumb_obj": "20250812_034218000_iOS2.6_e037_022400_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e037_022400_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 38,
@@ -865,7 +1142,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250812_034218000_iOS2.6_e038_023650_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e038_023650_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 39,
@@ -877,7 +1161,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 25,
-      "thumb_obj": "20250812_034218000_iOS2.6_e039_024900_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e039_024900_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 40,
@@ -889,7 +1181,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 27,
-      "thumb_obj": "20250812_034218000_iOS2.6_e040_025600_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e040_025600_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 41,
@@ -901,7 +1200,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 27,
-      "thumb_obj": "20250812_034218000_iOS2.6_e041_026250_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e041_026250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 42,
@@ -913,7 +1219,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 59,
-      "thumb_obj": "20250812_034218000_iOS2.6_e042_026350_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e042_026350_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 43,
@@ -925,7 +1238,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250812_034218000_iOS2.6_e043_026950_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e043_026950_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 44,
@@ -937,7 +1257,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250812_034218000_iOS2.6_e044_027550_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e044_027550_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 45,
@@ -949,7 +1277,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250812_034218000_iOS2.6_e045_028250_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e045_028250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 46,
@@ -961,7 +1297,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250812_034218000_iOS2.6_e046_028950_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e046_028950_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 47,
@@ -973,7 +1317,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 9,
-      "thumb_obj": "20250812_034218000_iOS2.6_e047_029750_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e047_029750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 48,
@@ -985,7 +1337,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 7,
-      "thumb_obj": "20250812_034218000_iOS2.6_e048_030600_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e048_030600_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 49,
@@ -997,7 +1357,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 42,
-      "thumb_obj": "20250812_034218000_iOS2.6_e049_031200_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e049_031200_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 50,
@@ -1009,7 +1376,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 42,
-      "thumb_obj": "20250812_034218000_iOS2.6_e050_031799_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e050_031799_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 51,
@@ -1021,7 +1395,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250812_034218000_iOS2.6_e051_032400_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e051_032400_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 52,
@@ -1033,7 +1414,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250812_034218000_iOS2.6_e052_032950_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e052_032950_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 53,
@@ -1045,7 +1434,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250812_034218000_iOS2.6_e053_033050_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e053_033050_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 54,
@@ -1057,7 +1454,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 1,
-      "thumb_obj": "20250812_034218000_iOS2.6_e054_033250_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e054_033250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 55,
@@ -1069,7 +1474,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250812_034218000_iOS2.6_e055_033849_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e055_033849_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 56,
@@ -1081,7 +1494,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 5,
-      "thumb_obj": "20250812_034218000_iOS2.6_e056_034450_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e056_034450_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 57,
@@ -1093,7 +1514,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 60,
-      "thumb_obj": "20250812_034218000_iOS2.6_e057_035050_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e057_035050_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 58,
@@ -1105,7 +1533,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "20250812_034218000_iOS2.6_e058_036100_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e058_036100_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 59,
@@ -1117,7 +1553,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "20250812_034218000_iOS2.6_e059_037400_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e059_037400_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 60,
@@ -1129,7 +1572,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 42,
-      "thumb_obj": "20250812_034218000_iOS2.6_e060_038150_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e060_038150_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 61,
@@ -1141,7 +1591,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250812_034218000_iOS2.6_e061_038500_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e061_038500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 62,
@@ -1153,7 +1611,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "20250812_034218000_iOS2.6_e062_038849_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e062_038849_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 63,
@@ -1165,7 +1630,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "20250812_034218000_iOS2.6_e063_039450_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e063_039450_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 64,
@@ -1177,7 +1649,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "20250812_034218000_iOS2.6_e064_040050_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e064_040050_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 65,
@@ -1189,7 +1668,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250812_034218000_iOS2.6_e065_040550_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e065_040550_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 66,
@@ -1201,7 +1687,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250812_034218000_iOS2.6_e066_041050_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e066_041050_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 67,
@@ -1213,7 +1706,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 41,
-      "thumb_obj": "20250812_034218000_iOS2.6_e067_042300_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e067_042300_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 68,
@@ -1225,7 +1726,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 41,
-      "thumb_obj": "20250812_034218000_iOS2.6_e068_043600_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e068_043600_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 69,
@@ -1237,7 +1746,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 58,
-      "thumb_obj": "20250812_034218000_iOS2.6_e069_044250_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e069_044250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 70,
@@ -1249,7 +1765,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 32,
-      "thumb_obj": "20250812_034218000_iOS2.6_e070_044900_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e070_044900_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 71,
@@ -1261,7 +1785,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250812_034218000_iOS2.6_e071_045350_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e071_045350_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 72,
@@ -1273,7 +1804,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 50,
-      "thumb_obj": "20250812_034218000_iOS2.6_e072_045800_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e072_045800_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 73,
@@ -1285,14 +1824,21 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250812_034218000_iOS2.6_e073_045950_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2.6_e073_045950_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     }
   ],
   "cycles": [
-    "Blue",
-    "Blue Blue↓ Yellow Blue Green↓ Unknown Blue↓ Blue Yellow↓ Pink/Magenta Blue↓ Blue Blue↓ Blue Pink/Magenta Yellow↓ Blue Blue Pink/Magenta Blue↑ Blue Blue Blue Blue Pink/Magenta↓ Green↑ Unknown Blue Blue↓ Blue Unknown Blue Blue Unknown Unknown Pink/Magenta Pink/Magenta Blue",
-    "Unknown↓ Unknown Unknown Unknown Blue Blue↓ Blue↓ Blue↓ Unknown↓ Unknown↑ Unknown Unknown Blue Blue↓ Blue↑ Green↑ Blue↓ Yellow↑ Unknown Yellow↑ Blue Unknown Blue↑ Blue Pink/Magenta Blue Blue Blue Green↑",
-    "Green↑ Unknown Unknown↑ Blue Unknown↓ Blue"
+    "Blue V0",
+    "Blue V0 Blue↓ V0 Yellow V0 Blue V0 Green↓ V0 Unknown V0 Blue↓ V0 Blue V0 Yellow↓ V0 Pink/Magenta V0 Blue↓ V0 Blue V0 Blue↓ V0 Blue V0 Pink/Magenta V0 Yellow↓ V0 Blue V0 Blue V0 Pink/Magenta V0 Blue↑ V0 Blue V0 Blue V0 Blue V0 Blue V0 Pink/Magenta↓ V0 Green↑ V0 Unknown V0 Blue V0 Blue↓ V0 Blue V0 Unknown V0 Blue V0 Blue V0 Unknown V0 Unknown V0 Pink/Magenta V0 Pink/Magenta V0 Blue V0",
+    "Unknown↓ V0 Unknown V0 Unknown V0 Unknown V0 Blue V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Unknown↓ V0 Unknown↑ V0 Unknown V0 Unknown V0 Blue V0 Blue↓ V0 Blue↑ V0 Green↑ V0 Blue↓ V0 Yellow↑ V0 Unknown V0 Yellow↑ V0 Blue V0 Unknown V0 Blue↑ V0 Blue V0 Pink/Magenta V0 Blue V0 Blue V0 Blue V0 Green↑ V0",
+    "Green↑ V0 Unknown V0 Unknown↑ V0 Blue V0 Unknown↓ V0 Blue V0"
   ],
   "clustering": {
     "eps": 0.34,

--- a/public/sequences_merge/20250812_034218000_iOS2.json.sequence.json
+++ b/public/sequences_merge/20250812_034218000_iOS2.json.sequence.json
@@ -208,7 +208,7 @@
     }
   },
   "symbol_seq": "SJATAXVGBAWAEARBCG_AT",
-  "symbol_seq_enhanced": "Unknown Blue Unknown↑ Unknown Pink/Magenta Blue Blue Unknown Blue↓ Unknown Blue Blue Blue Unknown Unknown↓",
+  "symbol_seq_enhanced": "Unknown V0 Blue V0 Unknown↑ V0 Unknown V0 Pink/Magenta V0 Blue V0 Blue V0 Unknown V0 Blue↓ V0 Unknown V0 Blue V0 Blue V0 Blue V0 Unknown V0 Unknown↓ V0",
   "binary_seq": "100010100010001",
   "v_threshold": 0.576,
   "events": [
@@ -222,7 +222,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "20250812_034218000_iOS2_e000_000200_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2_e000_000200_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 1,
@@ -234,7 +241,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "20250812_034218000_iOS2_e001_000500_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2_e001_000500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 2,
@@ -246,7 +260,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 32,
-      "thumb_obj": "20250812_034218000_iOS2_e002_000700_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2_e002_000700_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 3,
@@ -258,7 +280,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 50,
-      "thumb_obj": "20250812_034218000_iOS2_e003_000950_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2_e003_000950_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 4,
@@ -270,7 +299,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "20250812_034218000_iOS2_e004_002300_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2_e004_002300_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 5,
@@ -282,7 +318,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250812_034218000_iOS2_e005_003600_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2_e005_003600_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 6,
@@ -294,7 +337,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250812_034218000_iOS2_e006_004050_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2_e006_004050_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 7,
@@ -306,7 +356,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 58,
-      "thumb_obj": "20250812_034218000_iOS2_e007_004550_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2_e007_004550_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 8,
@@ -318,7 +375,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 34,
-      "thumb_obj": "20250812_034218000_iOS2_e008_005250_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2_e008_005250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 9,
@@ -330,7 +395,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 42,
-      "thumb_obj": "20250812_034218000_iOS2_e009_005950_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2_e009_005950_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 10,
@@ -342,7 +414,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250812_034218000_iOS2_e010_006600_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2_e010_006600_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 11,
@@ -354,7 +433,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250812_034218000_iOS2_e011_007200_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2_e011_007200_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 12,
@@ -366,7 +452,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250812_034218000_iOS2_e012_007350_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2_e012_007350_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 13,
@@ -378,7 +471,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": -2,
-      "thumb_obj": "20250812_034218000_iOS2_e013_007550_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2_e013_007550_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 14,
@@ -390,12 +490,20 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 32,
-      "thumb_obj": "20250812_034218000_iOS2_e014_007850_obj.jpg"
+      "thumb_obj": "20250812_034218000_iOS2_e014_007850_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     }
   ],
   "cycles": [
-    "Unknown Blue Unknown↑ Unknown Pink/Magenta",
-    "Blue Blue Unknown Blue↓ Unknown Blue Blue Blue Unknown Unknown↓"
+    "Unknown V0 Blue V0 Unknown↑ V0 Unknown V0 Pink/Magenta V0",
+    "Blue V0 Blue V0 Unknown V0 Blue↓ V0 Unknown V0 Blue V0 Blue V0 Blue V0 Unknown V0 Unknown↓ V0"
   ],
   "clustering": {
     "eps": 0.34,

--- a/public/sequences_merge/20250812_034409000_iOS.json.sequence.json
+++ b/public/sequences_merge/20250812_034409000_iOS.json.sequence.json
@@ -123,7 +123,7 @@
     }
   },
   "symbol_seq": "AUFDDFAVANXD",
-  "symbol_seq_enhanced": "Green↓ Blue↑ Blue↓ Blue↓ Blue Unknown Blue↑ Blue Unknown Blue",
+  "symbol_seq_enhanced": "Green↓ V0 Blue↑ V0 Blue↓ V0 Blue↓ V0 Blue V0 Unknown V0 Blue↑ V0 Blue V0 Unknown V0 Blue V0",
   "binary_seq": "1010100000",
   "v_threshold": 0.42500000000000004,
   "events": [
@@ -137,7 +137,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 56,
-      "thumb_obj": "20250812_034409000_iOS_e000_000050_obj.jpg"
+      "thumb_obj": "20250812_034409000_iOS_e000_000050_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 1,
@@ -149,7 +157,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250812_034409000_iOS_e001_000650_obj.jpg"
+      "thumb_obj": "20250812_034409000_iOS_e001_000650_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 2,
@@ -161,7 +177,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250812_034409000_iOS_e002_001400_obj.jpg"
+      "thumb_obj": "20250812_034409000_iOS_e002_001400_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 3,
@@ -173,7 +197,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250812_034409000_iOS_e003_002000_obj.jpg"
+      "thumb_obj": "20250812_034409000_iOS_e003_002000_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 4,
@@ -185,7 +217,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250812_034409000_iOS_e004_002800_obj.jpg"
+      "thumb_obj": "20250812_034409000_iOS_e004_002800_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 5,
@@ -197,7 +236,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 53,
-      "thumb_obj": "20250812_034409000_iOS_e005_003699_obj.jpg"
+      "thumb_obj": "20250812_034409000_iOS_e005_003699_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 6,
@@ -209,7 +255,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250812_034409000_iOS_e006_004600_obj.jpg"
+      "thumb_obj": "20250812_034409000_iOS_e006_004600_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 7,
@@ -221,7 +275,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "20250812_034409000_iOS_e007_005550_obj.jpg"
+      "thumb_obj": "20250812_034409000_iOS_e007_005550_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 8,
@@ -233,7 +294,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 2,
-      "thumb_obj": "20250812_034409000_iOS_e008_006550_obj.jpg"
+      "thumb_obj": "20250812_034409000_iOS_e008_006550_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 9,
@@ -245,11 +313,18 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250812_034409000_iOS_e009_022878_obj.jpg"
+      "thumb_obj": "20250812_034409000_iOS_e009_022878_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     }
   ],
   "cycles": [
-    "Green↓ Blue↑ Blue↓ Blue↓ Blue Unknown Blue↑ Blue Unknown Blue"
+    "Green↓ V0 Blue↑ V0 Blue↓ V0 Blue↓ V0 Blue V0 Unknown V0 Blue↑ V0 Blue V0 Unknown V0 Blue V0"
   ],
   "clustering": {
     "eps": 0.34,

--- a/public/sequences_merge/20250812_034409000_iOS2.json.sequence.json
+++ b/public/sequences_merge/20250812_034409000_iOS2.json.sequence.json
@@ -38,7 +38,7 @@
     }
   },
   "symbol_seq": "AJ",
-  "symbol_seq_enhanced": "Green↑",
+  "symbol_seq_enhanced": "Green↑ V0",
   "binary_seq": "1",
   "v_threshold": 0.41,
   "events": [
@@ -52,11 +52,19 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 24,
-      "thumb_obj": "20250812_034409000_iOS2_e000_050000_obj.jpg"
+      "thumb_obj": "20250812_034409000_iOS2_e000_050000_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     }
   ],
   "cycles": [
-    "Green↑"
+    "Green↑ V0"
   ],
   "clustering": {
     "eps": 0.34,

--- a/public/sequences_merge/20250815_204153000_iOS2.json.sequence.json
+++ b/public/sequences_merge/20250815_204153000_iOS2.json.sequence.json
@@ -395,7 +395,7 @@
     }
   },
   "symbol_seq": "AWFDXATABAHCCJOAJFFAFASCCDBABGGGGDAQAX_BBGCJGAMBGCOBQHBGBAAAAOYXXFBLFAOAOBAOAAADFOTTAFAIAGACACAGTTMBBABAKAKBCGJJAFFEEBCXZZBBBHWAGAINTABADAVAVOADDFNAOWDDAAZATXN",
-  "symbol_seq_enhanced": "Unknown↓ Blue↑ Blue Unknown Blue Pink/Magenta Pink/Magenta Pink/Magenta↓ Blue Blue↑ Blue Blue↓ Blue Blue Blue Blue↑ Blue↓ Blue Unknown Blue↑ Blue↑ Blue↓ Blue Pink/Magenta↓ Blue Blue↓ Blue↓ Blue Blue Green Unknown Green↑ Green Blue Blue Blue↓ Blue↓ Unknown↑ Blue Blue Blue Blue Blue↑ Yellow↑ Unknown↑ Blue Blue↑ Blue↑ Blue↑ Blue↑ Blue↑ Unknown↑ Unknown↑ Unknown↑ Blue↓ Green↑ Blue↓ Green Green Unknown Blue Blue↓ Blue↑ Blue↑ Blue↑ Blue Blue Pink/Magenta↓ Pink/Magenta↓ Pink/Magenta Pink/Magenta Pink/Magenta Pink/Magenta Pink/Magenta Pink/Magenta↓ Pink/Magenta↓ Pink/Magenta↓ Blue↑ Blue↑ Blue Blue↑ Blue Pink/Magenta↓ Pink/Magenta↓ Blue↓ Blue Blue↓ Blue↑ Blue↑ Blue Blue Blue Unknown Unknown Blue↓ Blue↓ Unknown↓ Unknown Unknown Blue↓ Blue↓ Blue Yellow↑ Yellow↑ Pink/Magenta Pink/Magenta↑ Blue↑ Pink/Magenta Pink/Magenta Yellow↓ Unknown↑ Unknown↓ Blue↑ Blue Blue↑ Blue↑ Blue↑ Blue↓ Green↓ Yellow Blue↑ Blue↑ Blue Unknown↑ Unknown↑ Unknown Blue",
+  "symbol_seq_enhanced": "Unknown↓ V0 Blue↑ V0 Blue V0 Unknown V0 Blue V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta↓ V0 Blue V0 Blue↑ V0 Blue V0 Blue↓ V0 Blue V0 Blue V0 Blue V0 Blue↑ V0 Blue↓ V0 Blue V0 Unknown V0 Blue↑ V0 Blue↑ V0 Blue↓ V0 Blue V0 Pink/Magenta↓ V0 Blue V0 Blue↓ V0 Blue↓ V0 Blue V0 Blue V0 Green V0 Unknown V0 Green↑ V0 Green V0 Blue V0 Blue V0 Blue↓ V0 Blue↓ V0 Unknown↑ V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue↑ V0 Yellow↑ V0 Unknown↑ V0 Blue V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Blue↓ V0 Green↑ V0 Blue↓ V0 Green V0 Green V0 Unknown V0 Blue V0 Blue↓ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue V0 Blue V0 Pink/Magenta↓ V0 Pink/Magenta↓ V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta↓ V0 Pink/Magenta↓ V0 Pink/Magenta↓ V0 Blue↑ V0 Blue↑ V0 Blue V0 Blue↑ V0 Blue V0 Pink/Magenta↓ V0 Pink/Magenta↓ V0 Blue↓ V0 Blue V0 Blue↓ V0 Blue↑ V0 Blue↑ V0 Blue V0 Blue V0 Blue V0 Unknown V0 Unknown V0 Blue↓ V0 Blue↓ V0 Unknown↓ V0 Unknown V0 Unknown V0 Blue↓ V0 Blue↓ V0 Blue V0 Yellow↑ V0 Yellow↑ V0 Pink/Magenta V0 Pink/Magenta↑ V0 Blue↑ V0 Pink/Magenta V0 Pink/Magenta V0 Yellow↓ V0 Unknown↑ V0 Unknown↓ V0 Blue↑ V0 Blue V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↓ V0 Green↓ V0 Yellow V0 Blue↑ V0 Blue↑ V0 Blue V0 Unknown↑ V0 Unknown↑ V0 Unknown V0 Blue V0",
   "binary_seq": "0110000000000010001010010101110001100000000010000000000001100001011000001100000110000111101100000000000010000000000000000000000",
   "v_threshold": 0.542,
   "events": [
@@ -409,7 +409,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 58,
-      "thumb_obj": "20250815_204153000_iOS2_e000_000183_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e000_000183_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 1,
@@ -421,7 +429,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250815_204153000_iOS2_e001_000416_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e001_000416_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 2,
@@ -433,7 +449,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250815_204153000_iOS2_e002_000483_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e002_000483_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 3,
@@ -445,7 +468,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 2,
-      "thumb_obj": "20250815_204153000_iOS2_e003_000533_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e003_000533_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 4,
@@ -457,7 +487,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250815_204153000_iOS2_e004_000567_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e004_000567_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 5,
@@ -469,7 +506,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "20250815_204153000_iOS2_e005_000616_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e005_000616_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 6,
@@ -481,7 +525,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 44,
-      "thumb_obj": "20250815_204153000_iOS2_e006_000683_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e006_000683_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 7,
@@ -493,7 +544,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 31,
-      "thumb_obj": "20250815_204153000_iOS2_e007_000733_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e007_000733_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 8,
@@ -505,7 +564,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250815_204153000_iOS2_e008_000767_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e008_000767_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 9,
@@ -517,7 +583,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250815_204153000_iOS2_e009_000816_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e009_000816_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 10,
@@ -529,7 +603,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "20250815_204153000_iOS2_e010_000867_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e010_000867_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 11,
@@ -541,7 +622,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "20250815_204153000_iOS2_e011_000916_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e011_000916_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 12,
@@ -553,7 +642,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250815_204153000_iOS2_e012_000967_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e012_000967_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 13,
@@ -565,7 +661,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "20250815_204153000_iOS2_e013_001016_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e013_001016_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 14,
@@ -577,7 +680,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250815_204153000_iOS2_e014_001083_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e014_001083_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 15,
@@ -589,7 +699,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250815_204153000_iOS2_e015_001150_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e015_001150_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 16,
@@ -601,7 +719,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250815_204153000_iOS2_e016_001216_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e016_001216_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 17,
@@ -613,7 +739,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250815_204153000_iOS2_e017_001283_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e017_001283_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 18,
@@ -625,7 +758,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 64,
-      "thumb_obj": "20250815_204153000_iOS2_e018_001350_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e018_001350_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 19,
@@ -637,7 +777,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250815_204153000_iOS2_e019_001416_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e019_001416_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 20,
@@ -649,7 +797,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250815_204153000_iOS2_e020_001483_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e020_001483_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 21,
@@ -661,7 +817,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250815_204153000_iOS2_e021_001549_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e021_001549_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 22,
@@ -673,7 +837,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250815_204153000_iOS2_e022_001616_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e022_001616_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 23,
@@ -685,7 +856,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 44,
-      "thumb_obj": "20250815_204153000_iOS2_e023_001683_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e023_001683_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 24,
@@ -697,7 +876,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250815_204153000_iOS2_e024_001750_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e024_001750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 25,
@@ -709,7 +895,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250815_204153000_iOS2_e025_001816_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e025_001816_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 26,
@@ -721,7 +915,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250815_204153000_iOS2_e026_001883_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e026_001883_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 27,
@@ -733,7 +935,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250815_204153000_iOS2_e027_001950_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e027_001950_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 28,
@@ -745,7 +954,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250815_204153000_iOS2_e028_002016_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e028_002016_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 29,
@@ -757,7 +973,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 65,
-      "thumb_obj": "20250815_204153000_iOS2_e029_002083_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e029_002083_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 30,
@@ -769,7 +992,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 50,
-      "thumb_obj": "20250815_204153000_iOS2_e030_002150_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e030_002150_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 31,
@@ -781,7 +1011,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": -3,
-      "thumb_obj": "20250815_204153000_iOS2_e031_002216_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e031_002216_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 32,
@@ -793,7 +1031,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 66,
-      "thumb_obj": "20250815_204153000_iOS2_e032_002283_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e032_002283_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 33,
@@ -805,7 +1050,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250815_204153000_iOS2_e033_002350_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e033_002350_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 34,
@@ -817,7 +1069,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250815_204153000_iOS2_e034_002416_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e034_002416_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 35,
@@ -829,7 +1088,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "20250815_204153000_iOS2_e035_002483_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e035_002483_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 36,
@@ -841,7 +1108,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250815_204153000_iOS2_e036_002550_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e036_002550_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 37,
@@ -853,7 +1128,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 7,
-      "thumb_obj": "20250815_204153000_iOS2_e037_002616_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e037_002616_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 38,
@@ -865,7 +1148,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250815_204153000_iOS2_e038_002683_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e038_002683_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 39,
@@ -877,7 +1167,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250815_204153000_iOS2_e039_002750_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e039_002750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 40,
@@ -889,7 +1186,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250815_204153000_iOS2_e040_002816_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e040_002816_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 41,
@@ -901,7 +1205,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "20250815_204153000_iOS2_e041_002883_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e041_002883_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 42,
@@ -913,7 +1224,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 52,
-      "thumb_obj": "20250815_204153000_iOS2_e042_002950_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e042_002950_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 43,
@@ -925,7 +1244,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "20250815_204153000_iOS2_e043_003016_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e043_003016_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 44,
@@ -937,7 +1264,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 43,
-      "thumb_obj": "20250815_204153000_iOS2_e044_003083_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e044_003083_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 45,
@@ -949,7 +1284,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250815_204153000_iOS2_e045_003150_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e045_003150_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 46,
@@ -961,7 +1303,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250815_204153000_iOS2_e046_003216_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e046_003216_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 47,
@@ -973,7 +1323,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250815_204153000_iOS2_e047_003283_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e047_003283_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 48,
@@ -985,7 +1343,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250815_204153000_iOS2_e048_003350_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e048_003350_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 49,
@@ -997,7 +1363,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250815_204153000_iOS2_e049_003416_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e049_003416_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 50,
@@ -1009,7 +1383,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "20250815_204153000_iOS2_e050_003483_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e050_003483_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 51,
@@ -1021,7 +1403,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "20250815_204153000_iOS2_e051_003550_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e051_003550_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 52,
@@ -1033,7 +1423,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 2,
-      "thumb_obj": "20250815_204153000_iOS2_e052_003616_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e052_003616_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 53,
@@ -1045,7 +1443,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 2,
-      "thumb_obj": "20250815_204153000_iOS2_e053_003683_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e053_003683_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 54,
@@ -1057,7 +1463,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250815_204153000_iOS2_e054_003750_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e054_003750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 55,
@@ -1069,7 +1483,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 60,
-      "thumb_obj": "20250815_204153000_iOS2_e055_003816_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e055_003816_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 56,
@@ -1081,7 +1503,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250815_204153000_iOS2_e056_003883_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e056_003883_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 57,
@@ -1093,7 +1523,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 41,
-      "thumb_obj": "20250815_204153000_iOS2_e057_003950_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e057_003950_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 58,
@@ -1105,7 +1542,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 41,
-      "thumb_obj": "20250815_204153000_iOS2_e058_004016_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e058_004016_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 59,
@@ -1117,7 +1561,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 61,
-      "thumb_obj": "20250815_204153000_iOS2_e059_004083_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e059_004083_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 60,
@@ -1129,7 +1580,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "20250815_204153000_iOS2_e060_004150_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e060_004150_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 61,
@@ -1141,7 +1599,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250815_204153000_iOS2_e061_004216_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e061_004216_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 62,
@@ -1153,7 +1619,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250815_204153000_iOS2_e062_004283_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e062_004283_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 63,
@@ -1165,7 +1639,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250815_204153000_iOS2_e063_004350_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e063_004350_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 64,
@@ -1177,7 +1659,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250815_204153000_iOS2_e064_004416_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e064_004416_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 65,
@@ -1189,7 +1679,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250815_204153000_iOS2_e065_004483_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e065_004483_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 66,
@@ -1201,7 +1698,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "20250815_204153000_iOS2_e066_004550_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e066_004550_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 67,
@@ -1213,7 +1717,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "20250815_204153000_iOS2_e067_004616_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e067_004616_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 68,
@@ -1225,7 +1737,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "20250815_204153000_iOS2_e068_004683_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e068_004683_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 69,
@@ -1237,7 +1757,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 54,
-      "thumb_obj": "20250815_204153000_iOS2_e069_004750_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e069_004750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 70,
@@ -1249,7 +1776,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 67,
-      "thumb_obj": "20250815_204153000_iOS2_e070_004816_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e070_004816_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 71,
@@ -1261,7 +1795,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 26,
-      "thumb_obj": "20250815_204153000_iOS2_e071_004883_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e071_004883_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 72,
@@ -1273,7 +1814,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 38,
-      "thumb_obj": "20250815_204153000_iOS2_e072_004949_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e072_004949_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 73,
@@ -1285,7 +1833,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 38,
-      "thumb_obj": "20250815_204153000_iOS2_e073_005016_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e073_005016_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 74,
@@ -1297,7 +1852,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 26,
-      "thumb_obj": "20250815_204153000_iOS2_e074_005083_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e074_005083_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 75,
@@ -1309,7 +1872,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "20250815_204153000_iOS2_e075_005150_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e075_005150_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 76,
@@ -1321,7 +1892,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "20250815_204153000_iOS2_e076_005216_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e076_005216_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 77,
@@ -1333,7 +1912,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "20250815_204153000_iOS2_e077_005283_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e077_005283_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 78,
@@ -1345,7 +1932,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250815_204153000_iOS2_e078_005350_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e078_005350_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 79,
@@ -1357,7 +1952,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250815_204153000_iOS2_e079_005416_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e079_005416_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 80,
@@ -1369,7 +1971,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250815_204153000_iOS2_e080_005483_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e080_005483_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 81,
@@ -1381,7 +1991,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250815_204153000_iOS2_e081_005550_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e081_005550_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 82,
@@ -1393,7 +2010,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 29,
-      "thumb_obj": "20250815_204153000_iOS2_e082_005616_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e082_005616_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 83,
@@ -1405,7 +2030,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 29,
-      "thumb_obj": "20250815_204153000_iOS2_e083_005683_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e083_005683_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 84,
@@ -1417,7 +2050,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250815_204153000_iOS2_e084_005750_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e084_005750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 85,
@@ -1429,7 +2070,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250815_204153000_iOS2_e085_005816_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e085_005816_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 86,
@@ -1441,7 +2089,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250815_204153000_iOS2_e086_005883_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e086_005883_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 87,
@@ -1453,7 +2109,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "20250815_204153000_iOS2_e087_005949_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e087_005949_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 88,
@@ -1465,7 +2129,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "20250815_204153000_iOS2_e088_006016_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e088_006016_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 89,
@@ -1477,7 +2149,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250815_204153000_iOS2_e089_006083_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e089_006083_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 90,
@@ -1489,7 +2168,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250815_204153000_iOS2_e090_006150_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e090_006150_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 91,
@@ -1501,7 +2187,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250815_204153000_iOS2_e091_006216_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e091_006216_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 92,
@@ -1513,7 +2206,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "20250815_204153000_iOS2_e092_006283_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e092_006283_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 93,
@@ -1525,7 +2225,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "20250815_204153000_iOS2_e093_006350_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e093_006350_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 94,
@@ -1537,7 +2244,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250815_204153000_iOS2_e094_006416_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e094_006416_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 95,
@@ -1549,7 +2264,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250815_204153000_iOS2_e095_006483_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e095_006483_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 96,
@@ -1561,7 +2284,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 2,
-      "thumb_obj": "20250815_204153000_iOS2_e096_006550_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e096_006550_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 97,
@@ -1573,7 +2304,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 49,
-      "thumb_obj": "20250815_204153000_iOS2_e097_006616_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e097_006616_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 98,
@@ -1585,7 +2323,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 49,
-      "thumb_obj": "20250815_204153000_iOS2_e098_006683_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e098_006683_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 99,
@@ -1597,7 +2342,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250815_204153000_iOS2_e099_006750_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e099_006750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 100,
@@ -1609,7 +2362,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250815_204153000_iOS2_e100_006816_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e100_006816_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 101,
@@ -1621,7 +2382,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250815_204153000_iOS2_e101_006883_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e101_006883_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 102,
@@ -1633,7 +2401,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "20250815_204153000_iOS2_e102_006949_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e102_006949_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 103,
@@ -1645,7 +2421,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "20250815_204153000_iOS2_e103_007016_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e103_007016_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 104,
@@ -1657,7 +2441,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 26,
-      "thumb_obj": "20250815_204153000_iOS2_e104_007083_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e104_007083_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 105,
@@ -1669,7 +2460,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 67,
-      "thumb_obj": "20250815_204153000_iOS2_e105_007150_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e105_007150_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 106,
@@ -1681,7 +2480,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "20250815_204153000_iOS2_e106_007216_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e106_007216_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 107,
@@ -1693,7 +2500,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "20250815_204153000_iOS2_e107_007283_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e107_007283_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 108,
@@ -1705,7 +2519,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 44,
-      "thumb_obj": "20250815_204153000_iOS2_e108_007350_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e108_007350_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 109,
@@ -1717,7 +2538,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 5,
-      "thumb_obj": "20250815_204153000_iOS2_e109_007416_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e109_007416_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 110,
@@ -1729,7 +2558,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 53,
-      "thumb_obj": "20250815_204153000_iOS2_e110_007483_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e110_007483_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 111,
@@ -1741,7 +2578,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 53,
-      "thumb_obj": "20250815_204153000_iOS2_e111_007550_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e111_007550_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 112,
@@ -1753,7 +2598,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "20250815_204153000_iOS2_e112_007616_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e112_007616_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 113,
@@ -1765,7 +2618,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250815_204153000_iOS2_e113_007683_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e113_007683_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 114,
@@ -1777,7 +2637,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250815_204153000_iOS2_e114_007750_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e114_007750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 115,
@@ -1789,7 +2657,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250815_204153000_iOS2_e115_007816_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e115_007816_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 116,
@@ -1801,7 +2677,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250815_204153000_iOS2_e116_007883_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e116_007883_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 117,
@@ -1813,7 +2697,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "20250815_204153000_iOS2_e117_007949_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e117_007949_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 118,
@@ -1825,7 +2717,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 41,
-      "thumb_obj": "20250815_204153000_iOS2_e118_008016_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e118_008016_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 119,
@@ -1837,7 +2737,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "20250815_204153000_iOS2_e119_008083_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e119_008083_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 120,
@@ -1849,7 +2756,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250815_204153000_iOS2_e120_008149_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e120_008149_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 121,
@@ -1861,7 +2776,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250815_204153000_iOS2_e121_008216_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e121_008216_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 122,
@@ -1873,7 +2796,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250815_204153000_iOS2_e122_008283_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e122_008283_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 123,
@@ -1885,7 +2815,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 68,
-      "thumb_obj": "20250815_204153000_iOS2_e123_008350_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e123_008350_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 124,
@@ -1897,7 +2835,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 32,
-      "thumb_obj": "20250815_204153000_iOS2_e124_008416_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e124_008416_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 125,
@@ -1909,7 +2855,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 2,
-      "thumb_obj": "20250815_204153000_iOS2_e125_008483_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e125_008483_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 126,
@@ -1921,11 +2874,18 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "20250815_204153000_iOS2_e126_008550_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS2_e126_008550_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     }
   ],
   "cycles": [
-    "Unknown↓ Blue↑ Blue Unknown Blue Pink/Magenta Pink/Magenta Pink/Magenta↓ Blue Blue↑ Blue Blue↓ Blue Blue Blue Blue↑ Blue↓ Blue Unknown Blue↑ Blue↑ Blue↓ Blue Pink/Magenta↓ Blue Blue↓ Blue↓ Blue Blue Green Unknown Green↑ Green Blue Blue Blue↓ Blue↓ Unknown↑ Blue Blue Blue Blue Blue↑ Yellow↑ Unknown↑ Blue Blue↑ Blue↑ Blue↑ Blue↑ Blue↑ Unknown↑ Unknown↑ Unknown↑ Blue↓ Green↑ Blue↓ Green Green Unknown Blue Blue↓ Blue↑ Blue↑ Blue↑ Blue Blue Pink/Magenta↓ Pink/Magenta↓ Pink/Magenta Pink/Magenta Pink/Magenta Pink/Magenta Pink/Magenta Pink/Magenta↓ Pink/Magenta↓ Pink/Magenta↓ Blue↑ Blue↑ Blue Blue↑ Blue Pink/Magenta↓ Pink/Magenta↓ Blue↓ Blue Blue↓ Blue↑ Blue↑ Blue Blue Blue Unknown Unknown Blue↓ Blue↓ Unknown↓ Unknown Unknown Blue↓ Blue↓ Blue Yellow↑ Yellow↑ Pink/Magenta Pink/Magenta↑ Blue↑ Pink/Magenta Pink/Magenta Yellow↓ Unknown↑ Unknown↓ Blue↑ Blue Blue↑ Blue↑ Blue↑ Blue↓ Green↓ Yellow Blue↑ Blue↑ Blue Unknown↑ Unknown↑ Unknown Blue"
+    "Unknown↓ V0 Blue↑ V0 Blue V0 Unknown V0 Blue V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta↓ V0 Blue V0 Blue↑ V0 Blue V0 Blue↓ V0 Blue V0 Blue V0 Blue V0 Blue↑ V0 Blue↓ V0 Blue V0 Unknown V0 Blue↑ V0 Blue↑ V0 Blue↓ V0 Blue V0 Pink/Magenta↓ V0 Blue V0 Blue↓ V0 Blue↓ V0 Blue V0 Blue V0 Green V0 Unknown V0 Green↑ V0 Green V0 Blue V0 Blue V0 Blue↓ V0 Blue↓ V0 Unknown↑ V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue↑ V0 Yellow↑ V0 Unknown↑ V0 Blue V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Blue↓ V0 Green↑ V0 Blue↓ V0 Green V0 Green V0 Unknown V0 Blue V0 Blue↓ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue V0 Blue V0 Pink/Magenta↓ V0 Pink/Magenta↓ V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta↓ V0 Pink/Magenta↓ V0 Pink/Magenta↓ V0 Blue↑ V0 Blue↑ V0 Blue V0 Blue↑ V0 Blue V0 Pink/Magenta↓ V0 Pink/Magenta↓ V0 Blue↓ V0 Blue V0 Blue↓ V0 Blue↑ V0 Blue↑ V0 Blue V0 Blue V0 Blue V0 Unknown V0 Unknown V0 Blue↓ V0 Blue↓ V0 Unknown↓ V0 Unknown V0 Unknown V0 Blue↓ V0 Blue↓ V0 Blue V0 Yellow↑ V0 Yellow↑ V0 Pink/Magenta V0 Pink/Magenta↑ V0 Blue↑ V0 Pink/Magenta V0 Pink/Magenta V0 Yellow↓ V0 Unknown↑ V0 Unknown↓ V0 Blue↑ V0 Blue V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↓ V0 Green↓ V0 Yellow V0 Blue↑ V0 Blue↑ V0 Blue V0 Unknown↑ V0 Unknown↑ V0 Unknown V0 Blue V0"
   ],
   "clustering": {
     "eps": 0.34,

--- a/public/sequences_merge/20250815_204153000_iOS3.json.sequence.json
+++ b/public/sequences_merge/20250815_204153000_iOS3.json.sequence.json
@@ -395,7 +395,7 @@
     }
   },
   "symbol_seq": "ZZBHAGNTADADAAYAOWDAZAMNFAABAPCGAQAQFOAVAWBBAAAVAYARABBFMAWBCBCAABCAHBYAAJNNACACABTDAUBAATYJCNNDAKAOAJAGARIAX",
-  "symbol_seq_enhanced": "Unknown Unknown Blue Yellow↑ Pink/Magenta Blue↑ Pink/Magenta Yellow↓ Yellow↓ Blue Blue Unknown Green↓ Yellow Blue↑ Unknown↑ Unknown↑ Blue Blue Blue Blue Blue Unknown↑ Blue↑ Blue Green↑ Green↑ Blue↓ Blue↑ Unknown↑ Unknown Blue Blue Blue↑ Blue Unknown↓ Green↓ Unknown↓ Blue↓ Blue↑ Blue↑ Blue↓ Blue↓ Unknown↓ Green↓ Green↓ Blue↓ Blue↓ Green↑ Unknown↓ Blue↑ Unknown Blue↑ Green↑ Blue Blue Pink/Magenta↓ Pink/Magenta Pink/Magenta Pink/Magenta↓ Blue↓ Green Green Unknown↓ Unknown↑ Blue↓ Blue↓ Blue↓ Blue↓ Blue↓ Pink/Magenta Green↓ Green↑ Pink/Magenta↓ Unknown↓ Yellow↑ Unknown↓",
+  "symbol_seq_enhanced": "Unknown V0 Unknown V0 Blue V0 Yellow↑ V0 Pink/Magenta V0 Blue↑ V0 Pink/Magenta V0 Yellow↓ V0 Yellow↓ V0 Blue V0 Blue V0 Unknown V0 Green↓ V0 Yellow V0 Blue↑ V0 Unknown↑ V0 Unknown↑ V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Unknown↑ V0 Blue↑ V0 Blue V0 Green↑ V0 Green↑ V0 Blue↓ V0 Blue↑ V0 Unknown↑ V0 Unknown V0 Blue V0 Blue V0 Blue↑ V0 Blue V0 Unknown↓ V0 Green↓ V0 Unknown↓ V0 Blue↓ V0 Blue↑ V0 Blue↑ V0 Blue↓ V0 Blue↓ V0 Unknown↓ V0 Green↓ V0 Green↓ V0 Blue↓ V0 Blue↓ V0 Green↑ V0 Unknown↓ V0 Blue↑ V0 Unknown V0 Blue↑ V0 Green↑ V0 Blue V0 Blue V0 Pink/Magenta↓ V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta↓ V0 Blue↓ V0 Green V0 Green V0 Unknown↓ V0 Unknown↑ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Pink/Magenta V0 Green↓ V0 Green↑ V0 Pink/Magenta↓ V0 Unknown↓ V0 Yellow↑ V0 Unknown↓ V0",
   "binary_seq": "00001001100000000100010001100000011000111000000001110011000100000110001000000",
   "v_threshold": 0.534,
   "events": [
@@ -409,7 +409,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 49,
-      "thumb_obj": "20250815_204153000_iOS3_e000_000400_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e000_000400_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 1,
@@ -421,7 +428,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 49,
-      "thumb_obj": "20250815_204153000_iOS3_e001_001300_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e001_001300_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 2,
@@ -433,7 +447,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250815_204153000_iOS3_e002_002250_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e002_002250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 3,
@@ -445,7 +466,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "20250815_204153000_iOS3_e003_003400_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e003_003400_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 4,
@@ -457,7 +486,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 26,
-      "thumb_obj": "20250815_204153000_iOS3_e004_004550_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e004_004550_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 5,
@@ -469,7 +505,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "20250815_204153000_iOS3_e005_005400_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e005_005400_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 6,
@@ -481,7 +525,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "20250815_204153000_iOS3_e006_006250_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e006_006250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 7,
@@ -493,7 +544,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 5,
-      "thumb_obj": "20250815_204153000_iOS3_e007_007050_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e007_007050_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 8,
@@ -505,7 +564,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 5,
-      "thumb_obj": "20250815_204153000_iOS3_e008_008200_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e008_008200_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 9,
@@ -517,7 +584,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250815_204153000_iOS3_e009_009200_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e009_009200_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 10,
@@ -529,7 +603,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250815_204153000_iOS3_e010_010050_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e010_010050_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 11,
@@ -541,7 +622,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "20250815_204153000_iOS3_e011_011250_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e011_011250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 12,
@@ -553,7 +641,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 41,
-      "thumb_obj": "20250815_204153000_iOS3_e012_012050_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e012_012050_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 13,
@@ -565,7 +661,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "20250815_204153000_iOS3_e013_012550_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e013_012550_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 14,
@@ -577,7 +680,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250815_204153000_iOS3_e014_013450_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e014_013450_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 15,
@@ -589,7 +700,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 68,
-      "thumb_obj": "20250815_204153000_iOS3_e015_014950_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e015_014950_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 16,
@@ -601,7 +720,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 7,
-      "thumb_obj": "20250815_204153000_iOS3_e016_015900_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e016_015900_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 17,
@@ -613,7 +740,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "20250815_204153000_iOS3_e017_016400_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e017_016400_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 18,
@@ -625,7 +759,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250815_204153000_iOS3_e018_017050_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e018_017050_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 19,
@@ -637,7 +778,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250815_204153000_iOS3_e019_017850_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e019_017850_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 20,
@@ -649,7 +797,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250815_204153000_iOS3_e020_018700_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e020_018700_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 21,
@@ -661,7 +816,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250815_204153000_iOS3_e021_019550_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e021_019550_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 22,
@@ -673,7 +835,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 9,
-      "thumb_obj": "20250815_204153000_iOS3_e022_020400_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e022_020400_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 23,
@@ -685,7 +855,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250815_204153000_iOS3_e023_020900_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e023_020900_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 24,
@@ -697,7 +875,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250815_204153000_iOS3_e024_021400_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e024_021400_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 25,
@@ -709,7 +894,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 65,
-      "thumb_obj": "20250815_204153000_iOS3_e025_022050_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e025_022050_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 26,
@@ -721,7 +914,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 65,
-      "thumb_obj": "20250815_204153000_iOS3_e026_022850_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e026_022850_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 27,
@@ -733,7 +934,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250815_204153000_iOS3_e027_023700_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e027_023700_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 28,
@@ -745,7 +954,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "20250815_204153000_iOS3_e028_024550_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e028_024550_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 29,
@@ -757,7 +974,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 53,
-      "thumb_obj": "20250815_204153000_iOS3_e029_025400_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e029_025400_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 30,
@@ -769,7 +994,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 58,
-      "thumb_obj": "20250815_204153000_iOS3_e030_026600_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e030_026600_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 31,
@@ -781,7 +1013,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250815_204153000_iOS3_e031_027900_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e031_027900_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 32,
@@ -793,7 +1032,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250815_204153000_iOS3_e032_028700_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e032_028700_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 33,
@@ -805,7 +1051,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250815_204153000_iOS3_e033_029550_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e033_029550_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 34,
@@ -817,7 +1071,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250815_204153000_iOS3_e034_030400_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e034_030400_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 35,
@@ -829,7 +1090,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 53,
-      "thumb_obj": "20250815_204153000_iOS3_e035_030900_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e035_030900_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 36,
@@ -841,7 +1110,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 45,
-      "thumb_obj": "20250815_204153000_iOS3_e036_031400_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e036_031400_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 37,
@@ -853,7 +1130,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 42,
-      "thumb_obj": "20250815_204153000_iOS3_e037_032049_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e037_032049_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 38,
@@ -865,7 +1150,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250815_204153000_iOS3_e038_032599_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e038_032599_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 39,
@@ -877,7 +1170,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250815_204153000_iOS3_e039_033099_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e039_033099_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 40,
@@ -889,7 +1190,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250815_204153000_iOS3_e040_033700_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e040_033700_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 41,
@@ -901,7 +1210,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250815_204153000_iOS3_e041_034550_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e041_034550_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 42,
@@ -913,7 +1230,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "20250815_204153000_iOS3_e042_035550_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e042_035550_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 43,
@@ -925,7 +1250,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 58,
-      "thumb_obj": "20250815_204153000_iOS3_e043_036400_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e043_036400_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 44,
@@ -937,7 +1270,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 69,
-      "thumb_obj": "20250815_204153000_iOS3_e044_037050_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e044_037050_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 45,
@@ -949,7 +1290,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 69,
-      "thumb_obj": "20250815_204153000_iOS3_e045_037550_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e045_037550_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 46,
@@ -961,7 +1310,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250815_204153000_iOS3_e046_038050_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e046_038050_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 47,
@@ -973,7 +1330,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250815_204153000_iOS3_e047_038700_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e047_038700_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 48,
@@ -985,7 +1350,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 69,
-      "thumb_obj": "20250815_204153000_iOS3_e048_039550_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e048_039550_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 49,
@@ -997,7 +1370,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 31,
-      "thumb_obj": "20250815_204153000_iOS3_e049_040400_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e049_040400_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 50,
@@ -1009,7 +1390,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250815_204153000_iOS3_e050_040900_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e050_040900_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 51,
@@ -1021,7 +1410,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "20250815_204153000_iOS3_e051_041400_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e051_041400_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 52,
@@ -1033,7 +1429,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250815_204153000_iOS3_e052_042050_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e052_042050_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 53,
@@ -1045,7 +1449,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 24,
-      "thumb_obj": "20250815_204153000_iOS3_e053_042550_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e053_042550_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 54,
@@ -1057,7 +1469,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "20250815_204153000_iOS3_e054_043050_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e054_043050_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 55,
@@ -1069,7 +1488,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "20250815_204153000_iOS3_e055_043700_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e055_043700_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 56,
@@ -1081,7 +1507,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 38,
-      "thumb_obj": "20250815_204153000_iOS3_e056_044550_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e056_044550_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 57,
@@ -1093,7 +1527,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 38,
-      "thumb_obj": "20250815_204153000_iOS3_e057_045400_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e057_045400_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 58,
@@ -1105,7 +1546,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 44,
-      "thumb_obj": "20250815_204153000_iOS3_e058_046550_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e058_046550_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 59,
@@ -1117,7 +1565,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "20250815_204153000_iOS3_e059_047550_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e059_047550_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 60,
@@ -1129,7 +1585,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250815_204153000_iOS3_e060_048400_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e060_048400_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 61,
@@ -1141,7 +1605,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 56,
-      "thumb_obj": "20250815_204153000_iOS3_e061_049200_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e061_049200_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 62,
@@ -1153,7 +1624,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 61,
-      "thumb_obj": "20250815_204153000_iOS3_e062_049700_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e062_049700_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 63,
@@ -1165,7 +1643,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 32,
-      "thumb_obj": "20250815_204153000_iOS3_e063_050400_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e063_050400_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 64,
@@ -1177,7 +1663,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "20250815_204153000_iOS3_e064_050900_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e064_050900_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 65,
@@ -1189,7 +1683,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "20250815_204153000_iOS3_e065_051400_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e065_051400_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 66,
@@ -1201,7 +1703,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250815_204153000_iOS3_e066_052250_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e066_052250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 67,
@@ -1213,7 +1723,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "20250815_204153000_iOS3_e067_053050_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e067_053050_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 68,
@@ -1225,7 +1743,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "20250815_204153000_iOS3_e068_053700_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e068_053700_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 69,
@@ -1237,7 +1763,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250815_204153000_iOS3_e069_054550_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e069_054550_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 70,
@@ -1249,7 +1783,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 29,
-      "thumb_obj": "20250815_204153000_iOS3_e070_055400_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e070_055400_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 71,
@@ -1261,7 +1802,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 41,
-      "thumb_obj": "20250815_204153000_iOS3_e071_055900_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e071_055900_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 72,
@@ -1273,7 +1822,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 24,
-      "thumb_obj": "20250815_204153000_iOS3_e072_056400_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e072_056400_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 73,
@@ -1285,7 +1842,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 26,
-      "thumb_obj": "20250815_204153000_iOS3_e073_057099_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e073_057099_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 74,
@@ -1297,7 +1862,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 42,
-      "thumb_obj": "20250815_204153000_iOS3_e074_057900_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e074_057900_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 75,
@@ -1309,7 +1882,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "20250815_204153000_iOS3_e075_058849_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e075_058849_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 76,
@@ -1321,11 +1902,19 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 50,
-      "thumb_obj": "20250815_204153000_iOS3_e076_079700_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS3_e076_079700_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     }
   ],
   "cycles": [
-    "Unknown Unknown Blue Yellow↑ Pink/Magenta Blue↑ Pink/Magenta Yellow↓ Yellow↓ Blue Blue Unknown Green↓ Yellow Blue↑ Unknown↑ Unknown↑ Blue Blue Blue Blue Blue Unknown↑ Blue↑ Blue Green↑ Green↑ Blue↓ Blue↑ Unknown↑ Unknown Blue Blue Blue↑ Blue Unknown↓ Green↓ Unknown↓ Blue↓ Blue↑ Blue↑ Blue↓ Blue↓ Unknown↓ Green↓ Green↓ Blue↓ Blue↓ Green↑ Unknown↓ Blue↑ Unknown Blue↑ Green↑ Blue Blue Pink/Magenta↓ Pink/Magenta Pink/Magenta Pink/Magenta↓ Blue↓ Green Green Unknown↓ Unknown↑ Blue↓ Blue↓ Blue↓ Blue↓ Blue↓ Pink/Magenta Green↓ Green↑ Pink/Magenta↓ Unknown↓ Yellow↑ Unknown↓"
+    "Unknown V0 Unknown V0 Blue V0 Yellow↑ V0 Pink/Magenta V0 Blue↑ V0 Pink/Magenta V0 Yellow↓ V0 Yellow↓ V0 Blue V0 Blue V0 Unknown V0 Green↓ V0 Yellow V0 Blue↑ V0 Unknown↑ V0 Unknown↑ V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Unknown↑ V0 Blue↑ V0 Blue V0 Green↑ V0 Green↑ V0 Blue↓ V0 Blue↑ V0 Unknown↑ V0 Unknown V0 Blue V0 Blue V0 Blue↑ V0 Blue V0 Unknown↓ V0 Green↓ V0 Unknown↓ V0 Blue↓ V0 Blue↑ V0 Blue↑ V0 Blue↓ V0 Blue↓ V0 Unknown↓ V0 Green↓ V0 Green↓ V0 Blue↓ V0 Blue↓ V0 Green↑ V0 Unknown↓ V0 Blue↑ V0 Unknown V0 Blue↑ V0 Green↑ V0 Blue V0 Blue V0 Pink/Magenta↓ V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta↓ V0 Blue↓ V0 Green V0 Green V0 Unknown↓ V0 Unknown↑ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Pink/Magenta V0 Green↓ V0 Green↑ V0 Pink/Magenta↓ V0 Unknown↓ V0 Yellow↑ V0 Unknown↓ V0"
   ],
   "clustering": {
     "eps": 0.34,

--- a/public/sequences_merge/20250815_204153000_iOS4.json.sequence.json
+++ b/public/sequences_merge/20250815_204153000_iOS4.json.sequence.json
@@ -378,7 +378,7 @@
     }
   },
   "symbol_seq": "DDALAXDANYDBDDXNALMAAXDBAMNATADHYGAHATAAIABABBAAAFCCGATBBNOOFAAFAHAHAWFAZFAFASJJAGV_FAOBNABB_A_BADAMMABAZATAUAUAXAEB",
-  "symbol_seq_enhanced": "Blue↓ Blue↓ Green↑ Unknown↓ Blue↓ Unknown↑ Unknown Blue↓ Blue↓ Blue↑ Blue↑ Unknown Blue↑ Green Blue Pink/Magenta↓ Unknown↑ Blue Blue↓ Unknown↓ Blue↑ Unknown↓ Yellow↓ Yellow↓ Unknown↑ Blue Unknown↓ Unknown Blue Blue Yellow↑ Pink/Magenta Blue Blue↓ Blue Pink/Magenta Pink/Magenta Blue↓ Blue Blue↓ Unknown↓ Green Blue Blue Blue Blue Blue Blue Blue↓ Pink/Magenta Pink/Magenta Unknown Blue Unknown↓ Blue↓ Pink/Magenta Unknown↓ Blue Blue↓ Pink/Magenta Pink/Magenta↓ Blue↓ Blue Green Blue↑ Blue↓ Blue Blue Blue Blue↑ Blue Blue Blue↓ Blue↓ Blue Blue Blue Blue↓ Pink/Magenta Unknown Unknown Green Green Blue↑ Unknown↓ Blue↓ Blue",
+  "symbol_seq_enhanced": "Blue↓ V0 Blue↓ V0 Green↑ V0 Unknown↓ V0 Blue↓ V0 Unknown↑ V0 Unknown V0 Blue↓ V0 Blue↓ V0 Blue↑ V0 Blue↑ V0 Unknown V0 Blue↑ V0 Green V0 Blue V0 Pink/Magenta↓ V0 Unknown↑ V0 Blue V0 Blue↓ V0 Unknown↓ V0 Blue↑ V0 Unknown↓ V0 Yellow↓ V0 Yellow↓ V0 Unknown↑ V0 Blue V0 Unknown↓ V0 Unknown V0 Blue V0 Blue V0 Yellow↑ V0 Pink/Magenta V0 Blue V0 Blue↓ V0 Blue V0 Pink/Magenta V0 Pink/Magenta V0 Blue↓ V0 Blue V0 Blue↓ V0 Unknown↓ V0 Green V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue↓ V0 Pink/Magenta V0 Pink/Magenta V0 Unknown V0 Blue V0 Unknown↓ V0 Blue↓ V0 Pink/Magenta V0 Unknown↓ V0 Blue V0 Blue↓ V0 Pink/Magenta V0 Pink/Magenta↓ V0 Blue↓ V0 Blue V0 Green V0 Blue↑ V0 Blue↓ V0 Blue V0 Blue V0 Blue V0 Blue↑ V0 Blue V0 Blue V0 Blue↓ V0 Blue↓ V0 Blue V0 Blue V0 Blue V0 Blue↓ V0 Pink/Magenta V0 Unknown V0 Unknown V0 Green V0 Green V0 Blue↑ V0 Unknown↓ V0 Blue↓ V0 Blue V0",
   "binary_seq": "000010100101100111000000101000000100000100100111011110000000001010000000010001100001011",
   "v_threshold": 0.542,
   "events": [
@@ -392,7 +392,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250815_204153000_iOS4_e000_000000_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e000_000000_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 1,
@@ -404,7 +412,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250815_204153000_iOS4_e001_000838_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e001_000838_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 2,
@@ -416,7 +432,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 1,
-      "thumb_obj": "20250815_204153000_iOS4_e002_001634_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e002_001634_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 3,
@@ -428,7 +452,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 50,
-      "thumb_obj": "20250815_204153000_iOS4_e003_002384_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e003_002384_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 4,
@@ -440,7 +472,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250815_204153000_iOS4_e004_003334_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e004_003334_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 5,
@@ -452,7 +492,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 27,
-      "thumb_obj": "20250815_204153000_iOS4_e005_004067_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e005_004067_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 6,
@@ -464,7 +512,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "20250815_204153000_iOS4_e006_004601_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e006_004601_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 7,
@@ -476,7 +531,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250815_204153000_iOS4_e007_005301_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e007_005301_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 8,
@@ -488,7 +551,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250815_204153000_iOS4_e008_005834_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e008_005834_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 9,
@@ -500,7 +571,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250815_204153000_iOS4_e009_006568_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e009_006568_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 10,
@@ -512,7 +591,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250815_204153000_iOS4_e010_007434_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e010_007434_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 11,
@@ -524,7 +611,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 2,
-      "thumb_obj": "20250815_204153000_iOS4_e011_008334_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e011_008334_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 12,
@@ -536,7 +630,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "20250815_204153000_iOS4_e012_009384_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e012_009384_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 13,
@@ -548,7 +650,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 1,
-      "thumb_obj": "20250815_204153000_iOS4_e013_010168_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e013_010168_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 14,
@@ -560,7 +669,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "20250815_204153000_iOS4_e014_010834_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e014_010834_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 15,
@@ -572,7 +688,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 70,
-      "thumb_obj": "20250815_204153000_iOS4_e015_011934_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e015_011934_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 16,
@@ -584,7 +708,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 2,
-      "thumb_obj": "20250815_204153000_iOS4_e016_012918_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e016_012918_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 17,
@@ -596,7 +728,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250815_204153000_iOS4_e017_013434_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e017_013434_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 18,
@@ -608,7 +747,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250815_204153000_iOS4_e018_014068_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e018_014068_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 19,
@@ -620,7 +767,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 7,
-      "thumb_obj": "20250815_204153000_iOS4_e019_015018_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e019_015018_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 20,
@@ -632,7 +787,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "20250815_204153000_iOS4_e020_015834_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e020_015834_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 21,
@@ -644,7 +807,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 32,
-      "thumb_obj": "20250815_204153000_iOS4_e021_016334_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e021_016334_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 22,
@@ -656,7 +827,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 5,
-      "thumb_obj": "20250815_204153000_iOS4_e022_016801_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e022_016801_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 23,
@@ -668,7 +847,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "20250815_204153000_iOS4_e023_017484_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e023_017484_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 24,
@@ -680,7 +867,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "20250815_204153000_iOS4_e024_017951_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e024_017951_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 25,
@@ -692,7 +887,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250815_204153000_iOS4_e025_018501_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e025_018501_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 26,
@@ -704,7 +906,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 31,
-      "thumb_obj": "20250815_204153000_iOS4_e026_019201_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e026_019201_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 27,
@@ -716,7 +926,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 32,
-      "thumb_obj": "20250815_204153000_iOS4_e027_019718_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e027_019718_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 28,
@@ -728,7 +945,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250815_204153000_iOS4_e028_020218_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e028_020218_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 29,
@@ -740,7 +964,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250815_204153000_iOS4_e029_020834_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e029_020834_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 30,
@@ -752,7 +983,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "20250815_204153000_iOS4_e030_021334_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e030_021334_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 31,
@@ -764,7 +1003,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 44,
-      "thumb_obj": "20250815_204153000_iOS4_e031_021834_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e031_021834_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 32,
@@ -776,7 +1022,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250815_204153000_iOS4_e032_022484_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e032_022484_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 33,
@@ -788,7 +1041,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250815_204153000_iOS4_e033_023334_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e033_023334_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 34,
@@ -800,7 +1061,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250815_204153000_iOS4_e034_024218_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e034_024218_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 35,
@@ -812,7 +1080,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 70,
-      "thumb_obj": "20250815_204153000_iOS4_e035_025067_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e035_025067_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 36,
@@ -824,7 +1099,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 54,
-      "thumb_obj": "20250815_204153000_iOS4_e036_025834_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e036_025834_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 37,
@@ -836,7 +1118,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250815_204153000_iOS4_e037_026484_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e037_026484_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 38,
@@ -848,7 +1138,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250815_204153000_iOS4_e038_027384_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e038_027384_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 39,
@@ -860,7 +1157,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250815_204153000_iOS4_e039_028284_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e039_028284_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 40,
@@ -872,7 +1177,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 32,
-      "thumb_obj": "20250815_204153000_iOS4_e040_029151_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e040_029151_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 41,
@@ -884,7 +1197,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 66,
-      "thumb_obj": "20250815_204153000_iOS4_e041_030051_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e041_030051_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 42,
@@ -896,7 +1216,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "20250815_204153000_iOS4_e042_030834_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e042_030834_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 43,
@@ -908,7 +1235,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "20250815_204153000_iOS4_e043_031484_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e043_031484_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 44,
@@ -920,7 +1254,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "20250815_204153000_iOS4_e044_032334_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e044_032334_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 45,
@@ -932,7 +1273,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250815_204153000_iOS4_e045_033284_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e045_033284_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 46,
@@ -944,7 +1292,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250815_204153000_iOS4_e046_034151_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e046_034151_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 47,
@@ -956,7 +1311,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250815_204153000_iOS4_e047_035068_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e047_035068_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 48,
@@ -968,7 +1330,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250815_204153000_iOS4_e048_035834_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e048_035834_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 49,
@@ -980,7 +1350,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 31,
-      "thumb_obj": "20250815_204153000_iOS4_e049_036334_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e049_036334_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 50,
@@ -992,7 +1369,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 31,
-      "thumb_obj": "20250815_204153000_iOS4_e050_036834_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e050_036834_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 51,
@@ -1004,7 +1388,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 58,
-      "thumb_obj": "20250815_204153000_iOS4_e051_037484_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e051_037484_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 52,
@@ -1016,7 +1407,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250815_204153000_iOS4_e052_037951_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e052_037951_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 53,
@@ -1028,7 +1426,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 68,
-      "thumb_obj": "20250815_204153000_iOS4_e053_038501_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e053_038501_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 54,
@@ -1040,7 +1446,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250815_204153000_iOS4_e054_039201_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e054_039201_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 55,
@@ -1052,7 +1466,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 54,
-      "thumb_obj": "20250815_204153000_iOS4_e055_040051_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e055_040051_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 56,
@@ -1064,7 +1485,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 64,
-      "thumb_obj": "20250815_204153000_iOS4_e056_040834_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e056_040834_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 57,
@@ -1076,7 +1505,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "20250815_204153000_iOS4_e057_041484_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e057_041484_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 58,
@@ -1088,7 +1524,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "20250815_204153000_iOS4_e058_042334_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e058_042334_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 59,
@@ -1100,7 +1544,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 26,
-      "thumb_obj": "20250815_204153000_iOS4_e059_043151_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e059_043151_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 60,
@@ -1112,7 +1563,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "20250815_204153000_iOS4_e060_044068_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e060_044068_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 61,
@@ -1124,7 +1583,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": -4,
-      "thumb_obj": "20250815_204153000_iOS4_e061_045068_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e061_045068_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 62,
@@ -1136,7 +1603,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250815_204153000_iOS4_e062_046068_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e062_046068_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 63,
@@ -1148,7 +1622,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 41,
-      "thumb_obj": "20250815_204153000_iOS4_e063_046834_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e063_046834_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 64,
@@ -1160,7 +1641,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250815_204153000_iOS4_e064_047484_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e064_047484_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 65,
@@ -1172,7 +1661,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "20250815_204153000_iOS4_e065_048334_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e065_048334_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 66,
@@ -1184,7 +1681,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250815_204153000_iOS4_e066_049151_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e066_049151_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 67,
@@ -1196,7 +1700,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250815_204153000_iOS4_e067_050051_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e067_050051_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 68,
@@ -1208,7 +1719,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250815_204153000_iOS4_e068_050834_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e068_050834_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 69,
@@ -1220,7 +1738,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": -4,
-      "thumb_obj": "20250815_204153000_iOS4_e069_051484_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e069_051484_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 70,
@@ -1232,7 +1758,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250815_204153000_iOS4_e070_052334_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e070_052334_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 71,
@@ -1244,7 +1777,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": -4,
-      "thumb_obj": "20250815_204153000_iOS4_e071_053151_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e071_053151_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 72,
@@ -1256,7 +1796,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250815_204153000_iOS4_e072_054051_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e072_054051_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 73,
@@ -1268,7 +1816,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250815_204153000_iOS4_e073_055051_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e073_055051_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 74,
@@ -1280,7 +1836,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250815_204153000_iOS4_e074_056068_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e074_056068_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 75,
@@ -1292,7 +1855,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250815_204153000_iOS4_e075_056834_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e075_056834_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 76,
@@ -1304,7 +1874,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "20250815_204153000_iOS4_e076_057484_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e076_057484_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 77,
@@ -1316,7 +1893,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "20250815_204153000_iOS4_e077_058334_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e077_058334_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 78,
@@ -1328,7 +1913,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 44,
-      "thumb_obj": "20250815_204153000_iOS4_e078_059151_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e078_059151_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 79,
@@ -1340,7 +1932,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 68,
-      "thumb_obj": "20250815_204153000_iOS4_e079_060051_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e079_060051_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 80,
@@ -1352,7 +1951,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 32,
-      "thumb_obj": "20250815_204153000_iOS4_e080_060834_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e080_060834_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 81,
@@ -1364,7 +1970,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 56,
-      "thumb_obj": "20250815_204153000_iOS4_e081_061484_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e081_061484_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 82,
@@ -1376,7 +1989,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 56,
-      "thumb_obj": "20250815_204153000_iOS4_e082_062334_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e082_062334_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 83,
@@ -1388,7 +2008,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250815_204153000_iOS4_e083_063284_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e083_063284_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 84,
@@ -1400,7 +2028,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 2,
-      "thumb_obj": "20250815_204153000_iOS4_e084_064151_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e084_064151_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 85,
@@ -1412,7 +2048,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 34,
-      "thumb_obj": "20250815_204153000_iOS4_e085_065051_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e085_065051_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 86,
@@ -1424,11 +2068,18 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250815_204153000_iOS4_e086_066068_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS4_e086_066068_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     }
   ],
   "cycles": [
-    "Blue↓ Blue↓ Green↑ Unknown↓ Blue↓ Unknown↑ Unknown Blue↓ Blue↓ Blue↑ Blue↑ Unknown Blue↑ Green Blue Pink/Magenta↓ Unknown↑ Blue Blue↓ Unknown↓ Blue↑ Unknown↓ Yellow↓ Yellow↓ Unknown↑ Blue Unknown↓ Unknown Blue Blue Yellow↑ Pink/Magenta Blue Blue↓ Blue Pink/Magenta Pink/Magenta Blue↓ Blue Blue↓ Unknown↓ Green Blue Blue Blue Blue Blue Blue Blue↓ Pink/Magenta Pink/Magenta Unknown Blue Unknown↓ Blue↓ Pink/Magenta Unknown↓ Blue Blue↓ Pink/Magenta Pink/Magenta↓ Blue↓ Blue Green Blue↑ Blue↓ Blue Blue Blue Blue↑ Blue Blue Blue↓ Blue↓ Blue Blue Blue Blue↓ Pink/Magenta Unknown Unknown Green Green Blue↑ Unknown↓ Blue↓ Blue"
+    "Blue↓ V0 Blue↓ V0 Green↑ V0 Unknown↓ V0 Blue↓ V0 Unknown↑ V0 Unknown V0 Blue↓ V0 Blue↓ V0 Blue↑ V0 Blue↑ V0 Unknown V0 Blue↑ V0 Green V0 Blue V0 Pink/Magenta↓ V0 Unknown↑ V0 Blue V0 Blue↓ V0 Unknown↓ V0 Blue↑ V0 Unknown↓ V0 Yellow↓ V0 Yellow↓ V0 Unknown↑ V0 Blue V0 Unknown↓ V0 Unknown V0 Blue V0 Blue V0 Yellow↑ V0 Pink/Magenta V0 Blue V0 Blue↓ V0 Blue V0 Pink/Magenta V0 Pink/Magenta V0 Blue↓ V0 Blue V0 Blue↓ V0 Unknown↓ V0 Green V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue↓ V0 Pink/Magenta V0 Pink/Magenta V0 Unknown V0 Blue V0 Unknown↓ V0 Blue↓ V0 Pink/Magenta V0 Unknown↓ V0 Blue V0 Blue↓ V0 Pink/Magenta V0 Pink/Magenta↓ V0 Blue↓ V0 Blue V0 Green V0 Blue↑ V0 Blue↓ V0 Blue V0 Blue V0 Blue V0 Blue↑ V0 Blue V0 Blue V0 Blue↓ V0 Blue↓ V0 Blue V0 Blue V0 Blue V0 Blue↓ V0 Pink/Magenta V0 Unknown V0 Unknown V0 Green V0 Green V0 Blue↑ V0 Unknown↓ V0 Blue↓ V0 Blue V0"
   ],
   "clustering": {
     "eps": 0.34,

--- a/public/sequences_merge/20250815_204153000_iOS5.json.sequence.json
+++ b/public/sequences_merge/20250815_204153000_iOS5.json.sequence.json
@@ -157,7 +157,7 @@
     }
   },
   "symbol_seq": "AMAUAXDNAQFAI",
-  "symbol_seq_enhanced": "Blue Blue↓ Green Blue↑ Unknown Blue Blue↑ Green↑ Blue Pink/Magenta↓",
+  "symbol_seq_enhanced": "Blue V0 Blue↓ V0 Green V0 Blue↑ V0 Unknown V0 Blue V0 Blue↑ V0 Green↑ V0 Blue V0 Pink/Magenta↓ V0",
   "binary_seq": "0001011000",
   "v_threshold": 0.577,
   "events": [
@@ -171,7 +171,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250815_204153000_iOS5_e000_000399_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS5_e000_000399_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 1,
@@ -183,7 +190,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "20250815_204153000_iOS5_e001_001999_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS5_e001_001999_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 2,
@@ -195,7 +210,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 56,
-      "thumb_obj": "20250815_204153000_iOS5_e002_004499_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS5_e002_004499_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 3,
@@ -207,7 +229,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250815_204153000_iOS5_e003_008649_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS5_e003_008649_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 4,
@@ -219,7 +249,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 2,
-      "thumb_obj": "20250815_204153000_iOS5_e004_015349_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS5_e004_015349_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 5,
@@ -231,7 +268,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250815_204153000_iOS5_e005_021699_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS5_e005_021699_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 6,
@@ -243,7 +287,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "20250815_204153000_iOS5_e006_026699_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS5_e006_026699_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 7,
@@ -255,7 +307,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 65,
-      "thumb_obj": "20250815_204153000_iOS5_e007_033849_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS5_e007_033849_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 8,
@@ -267,7 +327,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250815_204153000_iOS5_e008_039299_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS5_e008_039299_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 9,
@@ -279,18 +346,26 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 67,
-      "thumb_obj": "20250815_204153000_iOS5_e009_076800_obj.jpg"
+      "thumb_obj": "20250815_204153000_iOS5_e009_076800_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     }
   ],
   "cycles": [
-    "Blue Blue↓",
-    "Green",
-    "Blue↑",
-    "Unknown",
-    "Blue",
-    "Blue↑",
-    "Green↑",
-    "Blue Pink/Magenta↓"
+    "Blue V0 Blue↓ V0",
+    "Green V0",
+    "Blue↑ V0",
+    "Unknown V0",
+    "Blue V0",
+    "Blue↑ V0",
+    "Green↑ V0",
+    "Blue V0 Pink/Magenta↓ V0"
   ],
   "clustering": {
     "eps": 0.34,

--- a/public/sequences_merge/20250816_033400000_iOS.2.json.sequence.json
+++ b/public/sequences_merge/20250816_033400000_iOS.2.json.sequence.json
@@ -106,7 +106,7 @@
     }
   },
   "symbol_seq": "MDASCG",
-  "symbol_seq_enhanced": "Blue↓ Blue↑ Unknown Blue Blue↓",
+  "symbol_seq_enhanced": "Blue↓ V0 Blue↑ V0 Unknown V0 Blue V0 Blue↓ V0",
   "binary_seq": "00001",
   "v_threshold": 0.618,
   "events": [
@@ -120,7 +120,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "20250816_033400000_iOS.2_e000_002000_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS.2_e000_002000_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 1,
@@ -132,7 +140,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250816_033400000_iOS.2_e001_006550_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS.2_e001_006550_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 2,
@@ -144,7 +160,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 64,
-      "thumb_obj": "20250816_033400000_iOS.2_e002_014050_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS.2_e002_014050_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 3,
@@ -156,7 +179,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250816_033400000_iOS.2_e003_026050_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS.2_e003_026050_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 4,
@@ -168,15 +198,23 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250816_033400000_iOS.2_e004_048849_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS.2_e004_048849_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     }
   ],
   "cycles": [
-    "Blue↓",
-    "Blue↑",
-    "Unknown",
-    "Blue",
-    "Blue↓"
+    "Blue↓ V0",
+    "Blue↑ V0",
+    "Unknown V0",
+    "Blue V0",
+    "Blue↓ V0"
   ],
   "clustering": {
     "eps": 0.34,

--- a/public/sequences_merge/20250816_033400000_iOS.json.sequence.json
+++ b/public/sequences_merge/20250816_033400000_iOS.json.sequence.json
@@ -293,7 +293,7 @@
     }
   },
   "symbol_seq": "MGBAJAXFFFDDDDXAAFTTGGAKCCAOAOMONNBBJAADDFAAAFFFAXZZCCCCCDFFFBBABABABJGGGGGGGGAAAA_AQAQAVBBBB_AUAUAUDGCCCAJGG",
-  "symbol_seq_enhanced": "Blue↑ Blue Blue↑ Blue Blue Unknown↓ Blue↑ Blue↑ Blue↑ Blue Blue Blue Blue Unknown Blue Blue Blue Pink/Magenta Pink/Magenta Blue Blue Pink/Magenta↓ Blue Blue Green↓ Green↓ Blue Blue↓ Blue↓ Blue↓ Blue Blue Blue Blue Blue Blue Blue Blue↑ Blue↓ Blue↓ Blue↓ Blue Blue Blue Unknown↓ Unknown Unknown Blue↓ Blue↑ Blue↑ Blue↑ Blue↑ Blue↓ Blue↓ Blue↓ Blue↓ Blue Blue Pink/Magenta↓ Pink/Magenta↓ Pink/Magenta↓ Blue Blue↑ Blue↓ Blue↓ Blue↓ Blue↓ Blue↓ Blue Blue Blue Blue Blue↓ Blue↓ Pink/Magenta↓ Green Green Unknown Green Green Unknown↑ Green Green Green Blue↓ Blue↓ Blue Blue Blue Blue↓ Blue↓ Blue↓ Blue↓",
+  "symbol_seq_enhanced": "Blue↑ V0 Blue V0 Blue↑ V0 Blue V0 Blue V0 Unknown↓ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue V0 Blue V0 Blue V0 Blue V0 Unknown V0 Blue V0 Blue V0 Blue V0 Pink/Magenta V0 Pink/Magenta V0 Blue V0 Blue V0 Pink/Magenta↓ V0 Blue V0 Blue V0 Green↓ V0 Green↓ V0 Blue V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue↑ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue V0 Blue V0 Blue V0 Unknown↓ V0 Unknown V0 Unknown V0 Blue↓ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue V0 Blue V0 Pink/Magenta↓ V0 Pink/Magenta↓ V0 Pink/Magenta↓ V0 Blue V0 Blue↑ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue↓ V0 Blue↓ V0 Pink/Magenta↓ V0 Green V0 Green V0 Unknown V0 Green V0 Green V0 Unknown↑ V0 Green V0 Green V0 Green V0 Blue↓ V0 Blue↓ V0 Blue V0 Blue V0 Blue V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0",
   "binary_seq": "001100001111100001100000000000000001100000000110000100000011100111001111111110000000011110000",
   "v_threshold": 0.56,
   "events": [
@@ -307,7 +307,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "20250816_033400000_iOS_e000_000740_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e000_000740_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 1,
@@ -319,7 +327,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250816_033400000_iOS_e001_001860_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e001_001860_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 2,
@@ -331,7 +346,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250816_033400000_iOS_e002_002620_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e002_002620_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 3,
@@ -343,7 +366,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250816_033400000_iOS_e003_003820_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e003_003820_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 4,
@@ -355,7 +385,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "20250816_033400000_iOS_e004_004640_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e004_004640_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 5,
@@ -367,7 +404,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 50,
-      "thumb_obj": "20250816_033400000_iOS_e005_004840_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e005_004840_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 6,
@@ -379,7 +424,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250816_033400000_iOS_e006_005140_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e006_005140_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 7,
@@ -391,7 +444,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250816_033400000_iOS_e007_006080_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e007_006080_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 8,
@@ -403,7 +464,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250816_033400000_iOS_e008_007000_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e008_007000_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 9,
@@ -415,7 +484,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250816_033400000_iOS_e009_007240_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e009_007240_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 10,
@@ -427,7 +503,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250816_033400000_iOS_e010_007400_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e010_007400_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 11,
@@ -439,7 +522,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250816_033400000_iOS_e011_007540_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e011_007540_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 12,
@@ -451,7 +541,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250816_033400000_iOS_e012_007760_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e012_007760_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 13,
@@ -463,7 +560,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 2,
-      "thumb_obj": "20250816_033400000_iOS_e013_007959_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e013_007959_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 14,
@@ -475,7 +579,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250816_033400000_iOS_e014_008160_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e014_008160_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 15,
@@ -487,7 +598,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250816_033400000_iOS_e015_008360_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e015_008360_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 16,
@@ -499,7 +617,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250816_033400000_iOS_e016_008560_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e016_008560_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 17,
@@ -511,7 +636,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "20250816_033400000_iOS_e017_008760_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e017_008760_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 18,
@@ -523,7 +655,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "20250816_033400000_iOS_e018_008960_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e018_008960_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 19,
@@ -535,7 +674,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250816_033400000_iOS_e019_009160_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e019_009160_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 20,
@@ -547,7 +693,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250816_033400000_iOS_e020_009360_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e020_009360_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 21,
@@ -559,7 +712,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 29,
-      "thumb_obj": "20250816_033400000_iOS_e021_009560_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e021_009560_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 22,
@@ -571,7 +732,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250816_033400000_iOS_e022_009760_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e022_009760_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 23,
@@ -583,7 +751,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250816_033400000_iOS_e023_009960_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e023_009960_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 24,
@@ -595,7 +770,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 41,
-      "thumb_obj": "20250816_033400000_iOS_e024_010160_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e024_010160_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 25,
@@ -607,7 +790,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 41,
-      "thumb_obj": "20250816_033400000_iOS_e025_010360_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e025_010360_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 26,
@@ -619,7 +810,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "20250816_033400000_iOS_e026_010560_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e026_010560_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 27,
@@ -631,7 +829,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "20250816_033400000_iOS_e027_010760_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e027_010760_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 28,
@@ -643,7 +849,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "20250816_033400000_iOS_e028_010960_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e028_010960_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 29,
@@ -655,7 +869,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "20250816_033400000_iOS_e029_011160_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e029_011160_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 30,
@@ -667,7 +889,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250816_033400000_iOS_e030_011360_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e030_011360_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 31,
@@ -679,7 +908,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250816_033400000_iOS_e031_011560_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e031_011560_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 32,
@@ -691,7 +927,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "20250816_033400000_iOS_e032_011780_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e032_011780_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 33,
@@ -703,7 +946,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250816_033400000_iOS_e033_012000_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e033_012000_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 34,
@@ -715,7 +965,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250816_033400000_iOS_e034_012200_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e034_012200_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 35,
@@ -727,7 +984,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250816_033400000_iOS_e035_012400_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e035_012400_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 36,
@@ -739,7 +1003,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250816_033400000_iOS_e036_012600_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e036_012600_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 37,
@@ -751,7 +1022,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250816_033400000_iOS_e037_012800_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e037_012800_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 38,
@@ -763,7 +1042,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250816_033400000_iOS_e038_013000_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e038_013000_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 39,
@@ -775,7 +1062,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250816_033400000_iOS_e039_013200_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e039_013200_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 40,
@@ -787,7 +1082,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250816_033400000_iOS_e040_013400_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e040_013400_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 41,
@@ -799,7 +1102,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250816_033400000_iOS_e041_013600_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e041_013600_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 42,
@@ -811,7 +1121,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250816_033400000_iOS_e042_013800_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e042_013800_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 43,
@@ -823,7 +1140,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250816_033400000_iOS_e043_014000_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e043_014000_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 44,
@@ -835,7 +1159,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 50,
-      "thumb_obj": "20250816_033400000_iOS_e044_014200_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e044_014200_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 45,
@@ -847,7 +1179,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 49,
-      "thumb_obj": "20250816_033400000_iOS_e045_014400_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e045_014400_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 46,
@@ -859,7 +1198,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 49,
-      "thumb_obj": "20250816_033400000_iOS_e046_014600_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e046_014600_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 47,
@@ -871,7 +1217,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250816_033400000_iOS_e047_014800_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e047_014800_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 48,
@@ -883,7 +1237,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250816_033400000_iOS_e048_015000_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e048_015000_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 49,
@@ -895,7 +1257,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250816_033400000_iOS_e049_015200_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e049_015200_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 50,
@@ -907,7 +1277,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250816_033400000_iOS_e050_015400_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e050_015400_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 51,
@@ -919,7 +1297,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250816_033400000_iOS_e051_015600_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e051_015600_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 52,
@@ -931,7 +1317,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250816_033400000_iOS_e052_015800_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e052_015800_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 53,
@@ -943,7 +1337,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250816_033400000_iOS_e053_016000_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e053_016000_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 54,
@@ -955,7 +1357,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250816_033400000_iOS_e054_016200_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e054_016200_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 55,
@@ -967,7 +1377,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250816_033400000_iOS_e055_016400_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e055_016400_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 56,
@@ -979,7 +1397,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250816_033400000_iOS_e056_016600_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e056_016600_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 57,
@@ -991,7 +1416,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250816_033400000_iOS_e057_016799_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e057_016799_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 58,
@@ -1003,7 +1435,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 44,
-      "thumb_obj": "20250816_033400000_iOS_e058_017000_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e058_017000_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 59,
@@ -1015,7 +1455,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 44,
-      "thumb_obj": "20250816_033400000_iOS_e059_017200_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e059_017200_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 60,
@@ -1027,7 +1475,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 44,
-      "thumb_obj": "20250816_033400000_iOS_e060_017400_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e060_017400_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 61,
@@ -1039,7 +1495,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "20250816_033400000_iOS_e061_017600_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e061_017600_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 62,
@@ -1051,7 +1514,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250816_033400000_iOS_e062_017799_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e062_017799_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 63,
@@ -1063,7 +1534,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250816_033400000_iOS_e063_018000_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e063_018000_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 64,
@@ -1075,7 +1554,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250816_033400000_iOS_e064_018200_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e064_018200_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 65,
@@ -1087,7 +1574,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250816_033400000_iOS_e065_018400_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e065_018400_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 66,
@@ -1099,7 +1594,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250816_033400000_iOS_e066_018600_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e066_018600_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 67,
@@ -1111,7 +1614,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250816_033400000_iOS_e067_018799_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e067_018799_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 68,
@@ -1123,7 +1634,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250816_033400000_iOS_e068_019000_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e068_019000_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 69,
@@ -1135,7 +1653,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250816_033400000_iOS_e069_019200_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e069_019200_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 70,
@@ -1147,7 +1672,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250816_033400000_iOS_e070_019400_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e070_019400_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 71,
@@ -1159,7 +1691,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250816_033400000_iOS_e071_019600_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e071_019600_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 72,
@@ -1171,7 +1710,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250816_033400000_iOS_e072_019799_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e072_019799_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 73,
@@ -1183,7 +1730,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250816_033400000_iOS_e073_020000_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e073_020000_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 74,
@@ -1195,7 +1750,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": -5,
-      "thumb_obj": "20250816_033400000_iOS_e074_020200_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e074_020200_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 75,
@@ -1207,7 +1770,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 65,
-      "thumb_obj": "20250816_033400000_iOS_e075_020400_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e075_020400_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 76,
@@ -1219,7 +1789,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 65,
-      "thumb_obj": "20250816_033400000_iOS_e076_020600_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e076_020600_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 77,
@@ -1231,7 +1808,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 53,
-      "thumb_obj": "20250816_033400000_iOS_e077_020799_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e077_020799_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 78,
@@ -1243,7 +1827,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 66,
-      "thumb_obj": "20250816_033400000_iOS_e078_021000_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e078_021000_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 79,
@@ -1255,7 +1846,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 66,
-      "thumb_obj": "20250816_033400000_iOS_e079_021200_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e079_021200_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 80,
@@ -1267,7 +1865,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": -2,
-      "thumb_obj": "20250816_033400000_iOS_e080_021400_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e080_021400_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 81,
@@ -1279,7 +1885,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 56,
-      "thumb_obj": "20250816_033400000_iOS_e081_021600_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e081_021600_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 82,
@@ -1291,7 +1904,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 56,
-      "thumb_obj": "20250816_033400000_iOS_e082_021799_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e082_021799_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 83,
@@ -1303,7 +1923,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 56,
-      "thumb_obj": "20250816_033400000_iOS_e083_022000_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e083_022000_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 84,
@@ -1315,7 +1942,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250816_033400000_iOS_e084_022200_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e084_022200_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 85,
@@ -1327,7 +1962,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250816_033400000_iOS_e085_022400_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e085_022400_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 86,
@@ -1339,7 +1982,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250816_033400000_iOS_e086_022600_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e086_022600_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 87,
@@ -1351,7 +2001,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250816_033400000_iOS_e087_022799_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e087_022799_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 88,
@@ -1363,7 +2020,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250816_033400000_iOS_e088_023000_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e088_023000_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 89,
@@ -1375,7 +2039,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250816_033400000_iOS_e089_023200_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e089_023200_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 90,
@@ -1387,7 +2059,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "20250816_033400000_iOS_e090_023400_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e090_023400_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 91,
@@ -1399,7 +2079,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250816_033400000_iOS_e091_023600_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e091_023600_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 92,
@@ -1411,11 +2099,19 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250816_033400000_iOS_e092_023799_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_e092_023799_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     }
   ],
   "cycles": [
-    "Blue↑ Blue Blue↑ Blue Blue Unknown↓ Blue↑ Blue↑ Blue↑ Blue Blue Blue Blue Unknown Blue Blue Blue Pink/Magenta Pink/Magenta Blue Blue Pink/Magenta↓ Blue Blue Green↓ Green↓ Blue Blue↓ Blue↓ Blue↓ Blue Blue Blue Blue Blue Blue Blue Blue↑ Blue↓ Blue↓ Blue↓ Blue Blue Blue Unknown↓ Unknown Unknown Blue↓ Blue↑ Blue↑ Blue↑ Blue↑ Blue↓ Blue↓ Blue↓ Blue↓ Blue Blue Pink/Magenta↓ Pink/Magenta↓ Pink/Magenta↓ Blue Blue↑ Blue↓ Blue↓ Blue↓ Blue↓ Blue↓ Blue Blue Blue Blue Blue↓ Blue↓ Pink/Magenta↓ Green Green Unknown Green Green Unknown↑ Green Green Green Blue↓ Blue↓ Blue Blue Blue Blue↓ Blue↓ Blue↓ Blue↓"
+    "Blue↑ V0 Blue V0 Blue↑ V0 Blue V0 Blue V0 Unknown↓ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue V0 Blue V0 Blue V0 Blue V0 Unknown V0 Blue V0 Blue V0 Blue V0 Pink/Magenta V0 Pink/Magenta V0 Blue V0 Blue V0 Pink/Magenta↓ V0 Blue V0 Blue V0 Green↓ V0 Green↓ V0 Blue V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue↑ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue V0 Blue V0 Blue V0 Unknown↓ V0 Unknown V0 Unknown V0 Blue↓ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue V0 Blue V0 Pink/Magenta↓ V0 Pink/Magenta↓ V0 Pink/Magenta↓ V0 Blue V0 Blue↑ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue↓ V0 Blue↓ V0 Pink/Magenta↓ V0 Green V0 Green V0 Unknown V0 Green V0 Green V0 Unknown↑ V0 Green V0 Green V0 Green V0 Blue↓ V0 Blue↓ V0 Blue V0 Blue V0 Blue V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0"
   ],
   "clustering": {
     "eps": 0.34,

--- a/public/sequences_merge/20250816_033400000_iOS_conv.json.sequence.json
+++ b/public/sequences_merge/20250816_033400000_iOS_conv.json.sequence.json
@@ -429,7 +429,7 @@
     }
   },
   "symbol_seq": "DMBCAXFADXTAOJDAZCABABGGAQAUCGBBABGBGAAYXFFAOAAAFABAIAGACAGTBAAKCGAFFECZBBAGAGTADADAAFAOWDARNNABBCAQAQNOAVXABAAYAYABFAZAZAOABCBXAJAIACACABTDBAYCCNAKAKAGAGIAADAHAFAFABTGDBABAATATYJCCCNNDDNAKAKAOAJAJAGAGYILAAADDDDDAHDDOALALAXAXAZDDAPANY",
-  "symbol_seq_enhanced": "Blue Blue↑ Blue↑ Blue Unknown↓ Blue↑ Blue Blue Unknown Pink/Magenta Green↓ Blue Blue Blue↓ Unknown Blue↑ Pink/Magenta↓ Pink/Magenta↓ Blue↓ Blue Green Green Blue Blue↓ Blue↑ Blue↑ Blue↑ Unknown↑ Unknown↑ Blue↑ Blue↑ Unknown↑ Unknown↑ Blue↓ Blue↓ Green Blue↓ Blue↑ Blue↑ Blue Pink/Magenta↓ Pink/Magenta Pink/Magenta Pink/Magenta Pink/Magenta↓ Pink/Magenta↓ Blue Blue↑ Pink/Magenta↓ Blue Blue↓ Blue Blue Blue Unknown Blue Unknown Blue↓ Blue Pink/Magenta Pink/Magenta Pink/Magenta Yellow↓ Yellow↓ Blue Blue Blue↑ Green↑ Yellow Blue↑ Unknown↑ Blue Blue Blue Blue Blue Blue↑ Green↑ Green↑ Blue↑ Blue↑ Unknown↑ Unknown↓ Blue↓ Blue Blue↑ Green↓ Green↓ Blue Blue↑ Blue↓ Unknown↓ Unknown↓ Green↓ Blue↓ Green↑ Blue↑ Unknown Green↑ Pink/Magenta↓ Pink/Magenta↓ Pink/Magenta Pink/Magenta Pink/Magenta↓ Blue↓ Green Unknown↑ Blue↓ Blue↓ Blue↓ Pink/Magenta Pink/Magenta Pink/Magenta↓ Pink/Magenta↓ Yellow↑ Blue Blue↓ Blue↓ Unknown Pink/Magenta Pink/Magenta Pink/Magenta Pink/Magenta↓ Blue Blue↓ Green Green Unknown↓ Unknown↓ Unknown↑ Blue↓ Blue↓ Blue↓ Blue↓ Blue↓ Blue↓ Blue↓ Blue↓ Blue↑ Pink/Magenta Pink/Magenta Green↓ Green↑ Green↑ Pink/Magenta↓ Pink/Magenta↓ Unknown Yellow↑ Unknown↑ Blue Blue↓ Blue↓ Blue↑ Blue↓ Blue↓ Blue↓ Blue↓ Unknown Blue↓ Blue↓ Blue↓ Green↑ Green↑ Unknown↓ Unknown↓ Unknown↓ Blue↓ Blue↓ Unknown↑ Unknown↑ Unknown",
+  "symbol_seq_enhanced": "Blue V0 Blue↑ V0 Blue↑ V0 Blue V0 Unknown↓ V0 Blue↑ V0 Blue V0 Blue V0 Unknown V0 Pink/Magenta V0 Green↓ V0 Blue V0 Blue V0 Blue↓ V0 Unknown V0 Blue↑ V0 Pink/Magenta↓ V0 Pink/Magenta↓ V0 Blue↓ V0 Blue V0 Green V0 Green V0 Blue V0 Blue↓ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Unknown↑ V0 Unknown↑ V0 Blue↑ V0 Blue↑ V0 Unknown↑ V0 Unknown↑ V0 Blue↓ V0 Blue↓ V0 Green V0 Blue↓ V0 Blue↑ V0 Blue↑ V0 Blue V0 Pink/Magenta↓ V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta↓ V0 Pink/Magenta↓ V0 Blue V0 Blue↑ V0 Pink/Magenta↓ V0 Blue V0 Blue↓ V0 Blue V0 Blue V0 Blue V0 Unknown V0 Blue V0 Unknown V0 Blue↓ V0 Blue V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Yellow↓ V0 Yellow↓ V0 Blue V0 Blue V0 Blue↑ V0 Green↑ V0 Yellow V0 Blue↑ V0 Unknown↑ V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue↑ V0 Green↑ V0 Green↑ V0 Blue↑ V0 Blue↑ V0 Unknown↑ V0 Unknown↓ V0 Blue↓ V0 Blue V0 Blue↑ V0 Green↓ V0 Green↓ V0 Blue V0 Blue↑ V0 Blue↓ V0 Unknown↓ V0 Unknown↓ V0 Green↓ V0 Blue↓ V0 Green↑ V0 Blue↑ V0 Unknown V0 Green↑ V0 Pink/Magenta↓ V0 Pink/Magenta↓ V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta↓ V0 Blue↓ V0 Green V0 Unknown↑ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta↓ V0 Pink/Magenta↓ V0 Yellow↑ V0 Blue V0 Blue↓ V0 Blue↓ V0 Unknown V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta↓ V0 Blue V0 Blue↓ V0 Green V0 Green V0 Unknown↓ V0 Unknown↓ V0 Unknown↑ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue↑ V0 Pink/Magenta V0 Pink/Magenta V0 Green↓ V0 Green↑ V0 Green↑ V0 Pink/Magenta↓ V0 Pink/Magenta↓ V0 Unknown V0 Yellow↑ V0 Unknown↑ V0 Blue V0 Blue↓ V0 Blue↓ V0 Blue↑ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Unknown V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Green↑ V0 Green↑ V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Blue↓ V0 Blue↓ V0 Unknown↑ V0 Unknown↑ V0 Unknown V0",
   "binary_seq": "001100111100111001111010000010000001011110000011011011000001100000000001001101100000010011110000110111010001000000000000001000000011110000011000001000000000010000000011001",
   "v_threshold": 0.5366666666666667,
   "events": [
@@ -443,7 +443,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250816_033400000_iOS_conv_e000_000500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e000_000500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 1,
@@ -455,7 +462,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "20250816_033400000_iOS_conv_e001_001500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e001_001500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 2,
@@ -467,7 +482,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250816_033400000_iOS_conv_e002_002500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e002_002500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 3,
@@ -479,7 +502,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250816_033400000_iOS_conv_e003_003500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e003_003500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 4,
@@ -491,7 +521,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 50,
-      "thumb_obj": "20250816_033400000_iOS_conv_e004_004500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e004_004500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 5,
@@ -503,7 +541,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250816_033400000_iOS_conv_e005_005500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e005_005500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 6,
@@ -515,7 +561,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250816_033400000_iOS_conv_e006_006500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e006_006500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 7,
@@ -527,7 +580,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250816_033400000_iOS_conv_e007_007500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e007_007500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 8,
@@ -539,7 +599,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 2,
-      "thumb_obj": "20250816_033400000_iOS_conv_e008_008500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e008_008500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 9,
@@ -551,7 +618,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "20250816_033400000_iOS_conv_e009_009500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e009_009500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 10,
@@ -563,7 +637,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 41,
-      "thumb_obj": "20250816_033400000_iOS_conv_e010_010500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e010_010500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 11,
@@ -575,7 +657,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "20250816_033400000_iOS_conv_e011_011500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e011_011500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 12,
@@ -587,7 +676,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250816_033400000_iOS_conv_e012_012500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e012_012500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 13,
@@ -599,7 +695,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250816_033400000_iOS_conv_e013_013500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e013_013500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 14,
@@ -611,7 +715,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 49,
-      "thumb_obj": "20250816_033400000_iOS_conv_e014_014500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e014_014500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 15,
@@ -623,7 +734,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250816_033400000_iOS_conv_e015_015500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e015_015500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 16,
@@ -635,7 +754,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 44,
-      "thumb_obj": "20250816_033400000_iOS_conv_e016_016500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e016_016500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 17,
@@ -647,7 +774,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 44,
-      "thumb_obj": "20250816_033400000_iOS_conv_e017_017500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e017_017500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 18,
@@ -659,7 +794,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250816_033400000_iOS_conv_e018_018500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e018_018500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 19,
@@ -671,7 +814,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250816_033400000_iOS_conv_e019_019500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e019_019500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 20,
@@ -683,7 +833,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 65,
-      "thumb_obj": "20250816_033400000_iOS_conv_e020_020500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e020_020500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 21,
@@ -695,7 +852,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 56,
-      "thumb_obj": "20250816_033400000_iOS_conv_e021_021500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e021_021500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 22,
@@ -707,7 +871,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250816_033400000_iOS_conv_e022_022500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e022_022500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 23,
@@ -719,7 +890,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250816_033400000_iOS_conv_e023_023500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e023_023500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 24,
@@ -731,7 +910,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250816_033400000_iOS_conv_e024_024500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e024_024500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 25,
@@ -743,7 +930,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250816_033400000_iOS_conv_e025_025500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e025_025500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 26,
@@ -755,7 +950,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250816_033400000_iOS_conv_e026_026500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e026_026500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 27,
@@ -767,7 +970,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 43,
-      "thumb_obj": "20250816_033400000_iOS_conv_e027_027500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e027_027500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 28,
@@ -779,7 +990,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 43,
-      "thumb_obj": "20250816_033400000_iOS_conv_e028_028500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e028_028500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 29,
@@ -791,7 +1010,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250816_033400000_iOS_conv_e029_029500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e029_029500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 30,
@@ -803,7 +1030,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250816_033400000_iOS_conv_e030_030500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e030_030500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 31,
@@ -815,7 +1050,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "20250816_033400000_iOS_conv_e031_031500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e031_031500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 32,
@@ -827,7 +1070,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 2,
-      "thumb_obj": "20250816_033400000_iOS_conv_e032_032500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e032_032500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 33,
@@ -839,7 +1090,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250816_033400000_iOS_conv_e033_033500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e033_033500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 34,
@@ -851,7 +1110,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250816_033400000_iOS_conv_e034_034500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e034_034500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 35,
@@ -863,7 +1130,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 41,
-      "thumb_obj": "20250816_033400000_iOS_conv_e035_035500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e035_035500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 36,
@@ -875,7 +1149,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250816_033400000_iOS_conv_e036_036500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e036_036500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 37,
@@ -887,7 +1169,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250816_033400000_iOS_conv_e037_037500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e037_037500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 38,
@@ -899,7 +1189,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250816_033400000_iOS_conv_e038_038500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e038_038500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 39,
@@ -911,7 +1209,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250816_033400000_iOS_conv_e039_039500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e039_039500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 40,
@@ -923,7 +1228,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 44,
-      "thumb_obj": "20250816_033400000_iOS_conv_e040_040500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e040_040500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 41,
@@ -935,7 +1248,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 67,
-      "thumb_obj": "20250816_033400000_iOS_conv_e041_041500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e041_041500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 42,
@@ -947,7 +1267,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 26,
-      "thumb_obj": "20250816_033400000_iOS_conv_e042_042500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e042_042500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 43,
@@ -959,7 +1286,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 38,
-      "thumb_obj": "20250816_033400000_iOS_conv_e043_043500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e043_043500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 44,
@@ -971,7 +1305,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 26,
-      "thumb_obj": "20250816_033400000_iOS_conv_e044_044500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e044_044500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 45,
@@ -983,7 +1325,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "20250816_033400000_iOS_conv_e045_045500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e045_045500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 46,
@@ -995,7 +1345,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250816_033400000_iOS_conv_e046_046500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e046_046500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 47,
@@ -1007,7 +1364,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250816_033400000_iOS_conv_e047_047500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e047_047500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 48,
@@ -1019,7 +1384,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 29,
-      "thumb_obj": "20250816_033400000_iOS_conv_e048_048500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e048_048500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 49,
@@ -1031,7 +1404,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250816_033400000_iOS_conv_e049_049500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e049_049500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 50,
@@ -1043,7 +1423,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250816_033400000_iOS_conv_e050_050500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e050_050500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 51,
@@ -1055,7 +1443,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250816_033400000_iOS_conv_e051_051500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e051_051500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 52,
@@ -1067,7 +1462,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250816_033400000_iOS_conv_e052_052500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e052_052500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 53,
@@ -1079,7 +1481,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250816_033400000_iOS_conv_e053_053500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e053_053500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 54,
@@ -1091,7 +1500,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "20250816_033400000_iOS_conv_e054_054500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e054_054500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 55,
@@ -1103,7 +1519,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250816_033400000_iOS_conv_e055_055500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e055_055500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 56,
@@ -1115,7 +1538,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 49,
-      "thumb_obj": "20250816_033400000_iOS_conv_e056_056500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e056_056500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 57,
@@ -1127,7 +1557,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250816_033400000_iOS_conv_e057_057500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e057_057500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 58,
@@ -1139,7 +1577,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250816_033400000_iOS_conv_e058_058500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e058_058500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 59,
@@ -1151,7 +1596,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 26,
-      "thumb_obj": "20250816_033400000_iOS_conv_e059_059500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e059_059500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 60,
@@ -1163,7 +1615,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 26,
-      "thumb_obj": "20250816_033400000_iOS_conv_e060_060500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e060_060500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 61,
@@ -1175,7 +1634,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "20250816_033400000_iOS_conv_e061_061500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e061_061500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 62,
@@ -1187,7 +1653,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 5,
-      "thumb_obj": "20250816_033400000_iOS_conv_e062_062500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e062_062500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 63,
@@ -1199,7 +1673,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 5,
-      "thumb_obj": "20250816_033400000_iOS_conv_e063_063500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e063_063500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 64,
@@ -1211,7 +1693,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250816_033400000_iOS_conv_e064_064500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e064_064500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 65,
@@ -1223,7 +1712,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250816_033400000_iOS_conv_e065_065500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e065_065500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 66,
@@ -1235,7 +1731,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250816_033400000_iOS_conv_e066_066500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e066_066500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 67,
@@ -1247,7 +1751,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 41,
-      "thumb_obj": "20250816_033400000_iOS_conv_e067_067500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e067_067500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 68,
@@ -1259,7 +1771,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "20250816_033400000_iOS_conv_e068_068500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e068_068500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 69,
@@ -1271,7 +1790,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250816_033400000_iOS_conv_e069_069500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e069_069500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 70,
@@ -1283,7 +1810,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 42,
-      "thumb_obj": "20250816_033400000_iOS_conv_e070_070500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e070_070500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 71,
@@ -1295,7 +1830,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "20250816_033400000_iOS_conv_e071_071500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e071_071500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 72,
@@ -1307,7 +1849,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "20250816_033400000_iOS_conv_e072_072500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e072_072500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 73,
@@ -1319,7 +1868,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250816_033400000_iOS_conv_e073_073500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e073_073500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 74,
@@ -1331,7 +1887,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250816_033400000_iOS_conv_e074_074500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e074_074500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 75,
@@ -1343,7 +1906,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250816_033400000_iOS_conv_e075_075500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e075_075500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 76,
@@ -1355,7 +1925,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250816_033400000_iOS_conv_e076_076500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e076_076500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 77,
@@ -1367,7 +1945,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 65,
-      "thumb_obj": "20250816_033400000_iOS_conv_e077_077500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e077_077500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 78,
@@ -1379,7 +1965,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 65,
-      "thumb_obj": "20250816_033400000_iOS_conv_e078_078500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e078_078500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 79,
@@ -1391,7 +1985,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "20250816_033400000_iOS_conv_e079_079500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e079_079500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 80,
@@ -1403,7 +2005,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "20250816_033400000_iOS_conv_e080_080500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e080_080500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 81,
@@ -1415,7 +2025,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 53,
-      "thumb_obj": "20250816_033400000_iOS_conv_e081_081500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e081_081500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 82,
@@ -1427,7 +2045,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 2,
-      "thumb_obj": "20250816_033400000_iOS_conv_e082_082500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e082_082500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 83,
@@ -1439,7 +2065,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250816_033400000_iOS_conv_e083_083500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e083_083500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 84,
@@ -1451,7 +2085,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250816_033400000_iOS_conv_e084_084500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e084_084500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 85,
@@ -1463,7 +2104,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250816_033400000_iOS_conv_e085_085500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e085_085500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 86,
@@ -1475,7 +2124,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 45,
-      "thumb_obj": "20250816_033400000_iOS_conv_e086_086500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e086_086500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 87,
@@ -1487,7 +2144,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 45,
-      "thumb_obj": "20250816_033400000_iOS_conv_e087_087500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e087_087500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 88,
@@ -1499,7 +2164,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250816_033400000_iOS_conv_e088_088500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e088_088500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 89,
@@ -1511,7 +2183,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250816_033400000_iOS_conv_e089_089500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e089_089500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 90,
@@ -1523,7 +2203,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "20250816_033400000_iOS_conv_e090_090500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e090_090500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 91,
@@ -1535,7 +2223,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 68,
-      "thumb_obj": "20250816_033400000_iOS_conv_e091_091500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e091_091500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 92,
@@ -1547,7 +2243,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 68,
-      "thumb_obj": "20250816_033400000_iOS_conv_e092_092500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e092_092500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 93,
@@ -1559,7 +2263,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 41,
-      "thumb_obj": "20250816_033400000_iOS_conv_e093_093500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e093_093500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 94,
@@ -1571,7 +2283,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250816_033400000_iOS_conv_e094_094500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e094_094500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 95,
@@ -1583,7 +2303,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 69,
-      "thumb_obj": "20250816_033400000_iOS_conv_e095_095500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e095_095500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 96,
@@ -1595,7 +2323,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "20250816_033400000_iOS_conv_e096_096500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e096_096500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 97,
@@ -1607,7 +2343,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 2,
-      "thumb_obj": "20250816_033400000_iOS_conv_e097_097500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e097_097500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 98,
@@ -1619,7 +2362,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 24,
-      "thumb_obj": "20250816_033400000_iOS_conv_e098_098500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e098_098500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 99,
@@ -1631,7 +2382,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 67,
-      "thumb_obj": "20250816_033400000_iOS_conv_e099_099500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e099_099500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 100,
@@ -1643,7 +2402,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 38,
-      "thumb_obj": "20250816_033400000_iOS_conv_e100_100500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e100_100500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 101,
@@ -1655,7 +2422,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 38,
-      "thumb_obj": "20250816_033400000_iOS_conv_e101_101500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e101_101500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 102,
@@ -1667,7 +2441,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 44,
-      "thumb_obj": "20250816_033400000_iOS_conv_e102_102500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e102_102500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 103,
@@ -1679,7 +2460,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "20250816_033400000_iOS_conv_e103_103500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e103_103500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 104,
@@ -1691,7 +2480,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250816_033400000_iOS_conv_e104_104500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e104_104500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 105,
@@ -1703,7 +2500,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 61,
-      "thumb_obj": "20250816_033400000_iOS_conv_e105_105500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e105_105500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 106,
@@ -1715,7 +2519,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "20250816_033400000_iOS_conv_e106_106500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e106_106500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 107,
@@ -1727,7 +2539,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250816_033400000_iOS_conv_e107_107500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e107_107500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 108,
@@ -1739,7 +2559,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250816_033400000_iOS_conv_e108_108500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e108_108500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 109,
@@ -1751,7 +2579,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "20250816_033400000_iOS_conv_e109_109500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e109_109500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 110,
@@ -1763,7 +2599,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 29,
-      "thumb_obj": "20250816_033400000_iOS_conv_e110_110500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e110_110500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 111,
@@ -1775,7 +2618,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 29,
-      "thumb_obj": "20250816_033400000_iOS_conv_e111_111500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e111_111500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 112,
@@ -1787,7 +2637,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 26,
-      "thumb_obj": "20250816_033400000_iOS_conv_e112_112500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e112_112500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 113,
@@ -1799,7 +2657,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 26,
-      "thumb_obj": "20250816_033400000_iOS_conv_e113_113500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e113_113500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 114,
@@ -1811,7 +2677,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "20250816_033400000_iOS_conv_e114_114500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e114_114500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 115,
@@ -1823,7 +2697,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250816_033400000_iOS_conv_e115_115500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e115_115500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 116,
@@ -1835,7 +2716,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250816_033400000_iOS_conv_e116_116500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e116_116500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 117,
@@ -1847,7 +2736,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250816_033400000_iOS_conv_e117_117500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e117_117500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 118,
@@ -1859,7 +2756,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 31,
-      "thumb_obj": "20250816_033400000_iOS_conv_e118_118500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e118_118500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 119,
@@ -1871,7 +2775,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 54,
-      "thumb_obj": "20250816_033400000_iOS_conv_e119_102100_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e119_102100_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 120,
@@ -1883,7 +2794,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 54,
-      "thumb_obj": "20250816_033400000_iOS_conv_e120_102449_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e120_102449_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 121,
@@ -1895,7 +2813,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 44,
-      "thumb_obj": "20250816_033400000_iOS_conv_e121_102950_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e121_102950_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 122,
@@ -1907,7 +2832,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "20250816_033400000_iOS_conv_e122_103449_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e122_103449_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 123,
@@ -1919,7 +2852,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "20250816_033400000_iOS_conv_e123_103950_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e123_103950_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 124,
@@ -1931,7 +2871,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250816_033400000_iOS_conv_e124_104600_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e124_104600_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 125,
@@ -1943,7 +2891,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 61,
-      "thumb_obj": "20250816_033400000_iOS_conv_e125_105100_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e125_105100_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 126,
@@ -1955,7 +2910,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 61,
-      "thumb_obj": "20250816_033400000_iOS_conv_e126_105600_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e126_105600_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 127,
@@ -1967,7 +2929,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 32,
-      "thumb_obj": "20250816_033400000_iOS_conv_e127_106100_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e127_106100_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 128,
@@ -1979,7 +2949,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 32,
-      "thumb_obj": "20250816_033400000_iOS_conv_e128_106449_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e128_106449_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 129,
@@ -1991,7 +2969,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "20250816_033400000_iOS_conv_e129_106800_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e129_106800_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 130,
@@ -2003,7 +2989,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "20250816_033400000_iOS_conv_e130_107300_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e130_107300_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 131,
@@ -2015,7 +3009,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250816_033400000_iOS_conv_e131_107800_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e131_107800_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 132,
@@ -2027,7 +3029,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250816_033400000_iOS_conv_e132_108100_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e132_108100_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 133,
@@ -2039,7 +3049,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "20250816_033400000_iOS_conv_e133_108449_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e133_108449_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 134,
@@ -2051,7 +3069,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "20250816_033400000_iOS_conv_e134_108950_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e134_108950_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 135,
@@ -2063,7 +3089,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "20250816_033400000_iOS_conv_e135_109600_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e135_109600_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 136,
@@ -2075,7 +3109,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250816_033400000_iOS_conv_e136_110100_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e136_110100_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 137,
@@ -2087,7 +3129,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250816_033400000_iOS_conv_e137_110449_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e137_110449_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 138,
@@ -2099,7 +3149,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "20250816_033400000_iOS_conv_e138_110800_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e138_110800_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 139,
@@ -2111,7 +3169,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 29,
-      "thumb_obj": "20250816_033400000_iOS_conv_e139_111100_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e139_111100_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 140,
@@ -2123,7 +3188,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 29,
-      "thumb_obj": "20250816_033400000_iOS_conv_e140_111449_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e140_111449_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 141,
@@ -2135,7 +3207,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 41,
-      "thumb_obj": "20250816_033400000_iOS_conv_e141_111800_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e141_111800_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 142,
@@ -2147,7 +3227,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 24,
-      "thumb_obj": "20250816_033400000_iOS_conv_e142_112100_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e142_112100_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 143,
@@ -2159,7 +3247,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 24,
-      "thumb_obj": "20250816_033400000_iOS_conv_e143_112449_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e143_112449_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 144,
@@ -2171,7 +3267,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 26,
-      "thumb_obj": "20250816_033400000_iOS_conv_e144_112950_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e144_112950_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 145,
@@ -2183,7 +3287,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 26,
-      "thumb_obj": "20250816_033400000_iOS_conv_e145_113449_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e145_113449_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 146,
@@ -2195,7 +3307,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "20250816_033400000_iOS_conv_e146_113950_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e146_113950_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 147,
@@ -2207,7 +3326,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "20250816_033400000_iOS_conv_e147_114600_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e147_114600_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 148,
@@ -2219,7 +3346,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "20250816_033400000_iOS_conv_e148_115100_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e148_115100_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 149,
@@ -2231,7 +3366,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250816_033400000_iOS_conv_e149_115600_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e149_115600_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 150,
@@ -2243,7 +3385,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250816_033400000_iOS_conv_e150_116100_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e150_116100_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 151,
@@ -2255,7 +3405,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "20250816_033400000_iOS_conv_e151_116449_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e151_116449_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 152,
@@ -2267,7 +3425,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250816_033400000_iOS_conv_e152_116800_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e152_116800_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 153,
@@ -2279,7 +3445,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250816_033400000_iOS_conv_e153_117150_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e153_117150_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 154,
@@ -2291,7 +3465,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250816_033400000_iOS_conv_e154_117500_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e154_117500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 155,
@@ -2303,7 +3485,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250816_033400000_iOS_conv_e155_117800_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e155_117800_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 156,
@@ -2315,7 +3505,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250816_033400000_iOS_conv_e156_118100_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e156_118100_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 157,
@@ -2327,7 +3525,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 31,
-      "thumb_obj": "20250816_033400000_iOS_conv_e157_118449_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e157_118449_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 158,
@@ -2339,7 +3544,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250816_033400000_iOS_conv_e158_118950_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e158_118950_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 159,
@@ -2351,7 +3564,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250816_033400000_iOS_conv_e159_119600_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e159_119600_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 160,
@@ -2363,7 +3584,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "20250816_033400000_iOS_conv_e160_120100_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e160_120100_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 161,
@@ -2375,7 +3604,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 1,
-      "thumb_obj": "20250816_033400000_iOS_conv_e161_120449_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e161_120449_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 162,
@@ -2387,7 +3624,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 1,
-      "thumb_obj": "20250816_033400000_iOS_conv_e162_120800_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e162_120800_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 163,
@@ -2399,7 +3644,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 50,
-      "thumb_obj": "20250816_033400000_iOS_conv_e163_121100_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e163_121100_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 164,
@@ -2411,7 +3664,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 50,
-      "thumb_obj": "20250816_033400000_iOS_conv_e164_121449_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e164_121449_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 165,
@@ -2423,7 +3684,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 68,
-      "thumb_obj": "20250816_033400000_iOS_conv_e165_121800_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e165_121800_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 166,
@@ -2435,7 +3704,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250816_033400000_iOS_conv_e166_122100_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e166_122100_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 167,
@@ -2447,7 +3724,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "20250816_033400000_iOS_conv_e167_122449_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e167_122449_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 168,
@@ -2459,7 +3744,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 9,
-      "thumb_obj": "20250816_033400000_iOS_conv_e168_122800_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e168_122800_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 169,
@@ -2471,7 +3764,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 27,
-      "thumb_obj": "20250816_033400000_iOS_conv_e169_123100_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e169_123100_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 170,
@@ -2483,12 +3784,19 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "20250816_033400000_iOS_conv_e170_123449_obj.jpg"
+      "thumb_obj": "20250816_033400000_iOS_conv_e170_123449_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     }
   ],
   "cycles": [
-    "Blue Blue↑ Blue↑ Blue Unknown↓ Blue↑ Blue Blue Unknown Pink/Magenta Green↓ Blue Blue Blue↓ Unknown Blue↑ Pink/Magenta↓ Pink/Magenta↓ Blue↓ Blue Green Green Blue Blue↓ Blue↑ Blue↑ Blue↑ Unknown↑ Unknown↑ Blue↑ Blue↑ Unknown↑ Unknown↑ Blue↓ Blue↓ Green Blue↓ Blue↑ Blue↑ Blue Pink/Magenta↓ Pink/Magenta Pink/Magenta Pink/Magenta Pink/Magenta↓ Pink/Magenta↓ Blue Blue↑ Pink/Magenta↓ Blue Blue↓ Blue Blue Blue Unknown Blue Unknown Blue↓ Blue Pink/Magenta Pink/Magenta Pink/Magenta Yellow↓ Yellow↓ Blue Blue Blue↑ Green↑ Yellow Blue↑ Unknown↑ Blue Blue Blue Blue Blue Blue↑ Green↑ Green↑ Blue↑ Blue↑ Unknown↑ Unknown↓ Blue↓ Blue Blue↑ Green↓ Green↓ Blue Blue↑ Blue↓ Unknown↓ Unknown↓ Green↓ Blue↓ Green↑ Blue↑ Unknown Green↑ Pink/Magenta↓ Pink/Magenta↓ Pink/Magenta Pink/Magenta Pink/Magenta↓ Blue↓ Green Unknown↑ Blue↓ Blue↓ Blue↓ Pink/Magenta Pink/Magenta Pink/Magenta↓ Pink/Magenta↓ Yellow↑ Blue Blue↓ Blue↓ Unknown",
-    "Pink/Magenta Pink/Magenta Pink/Magenta Pink/Magenta↓ Blue Blue↓ Green Green Unknown↓ Unknown↓ Unknown↑ Blue↓ Blue↓ Blue↓ Blue↓ Blue↓ Blue↓ Blue↓ Blue↓ Blue↑ Pink/Magenta Pink/Magenta Green↓ Green↑ Green↑ Pink/Magenta↓ Pink/Magenta↓ Unknown Yellow↑ Unknown↑ Blue Blue↓ Blue↓ Blue↑ Blue↓ Blue↓ Blue↓ Blue↓ Unknown Blue↓ Blue↓ Blue↓ Green↑ Green↑ Unknown↓ Unknown↓ Unknown↓ Blue↓ Blue↓ Unknown↑ Unknown↑ Unknown"
+    "Blue V0 Blue↑ V0 Blue↑ V0 Blue V0 Unknown↓ V0 Blue↑ V0 Blue V0 Blue V0 Unknown V0 Pink/Magenta V0 Green↓ V0 Blue V0 Blue V0 Blue↓ V0 Unknown V0 Blue↑ V0 Pink/Magenta↓ V0 Pink/Magenta↓ V0 Blue↓ V0 Blue V0 Green V0 Green V0 Blue V0 Blue↓ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Unknown↑ V0 Unknown↑ V0 Blue↑ V0 Blue↑ V0 Unknown↑ V0 Unknown↑ V0 Blue↓ V0 Blue↓ V0 Green V0 Blue↓ V0 Blue↑ V0 Blue↑ V0 Blue V0 Pink/Magenta↓ V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta↓ V0 Pink/Magenta↓ V0 Blue V0 Blue↑ V0 Pink/Magenta↓ V0 Blue V0 Blue↓ V0 Blue V0 Blue V0 Blue V0 Unknown V0 Blue V0 Unknown V0 Blue↓ V0 Blue V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Yellow↓ V0 Yellow↓ V0 Blue V0 Blue V0 Blue↑ V0 Green↑ V0 Yellow V0 Blue↑ V0 Unknown↑ V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue↑ V0 Green↑ V0 Green↑ V0 Blue↑ V0 Blue↑ V0 Unknown↑ V0 Unknown↓ V0 Blue↓ V0 Blue V0 Blue↑ V0 Green↓ V0 Green↓ V0 Blue V0 Blue↑ V0 Blue↓ V0 Unknown↓ V0 Unknown↓ V0 Green↓ V0 Blue↓ V0 Green↑ V0 Blue↑ V0 Unknown V0 Green↑ V0 Pink/Magenta↓ V0 Pink/Magenta↓ V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta↓ V0 Blue↓ V0 Green V0 Unknown↑ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta↓ V0 Pink/Magenta↓ V0 Yellow↑ V0 Blue V0 Blue↓ V0 Blue↓ V0 Unknown V0",
+    "Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta↓ V0 Blue V0 Blue↓ V0 Green V0 Green V0 Unknown↓ V0 Unknown↓ V0 Unknown↑ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue↑ V0 Pink/Magenta V0 Pink/Magenta V0 Green↓ V0 Green↑ V0 Green↑ V0 Pink/Magenta↓ V0 Pink/Magenta↓ V0 Unknown V0 Yellow↑ V0 Unknown↑ V0 Blue V0 Blue↓ V0 Blue↓ V0 Blue↑ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Unknown V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Green↑ V0 Green↑ V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Blue↓ V0 Blue↓ V0 Unknown↑ V0 Unknown↑ V0 Unknown V0"
   ],
   "clustering": {
     "eps": 0.34,

--- a/public/sequences_merge/Michelle_orb_video.json.sequence.json
+++ b/public/sequences_merge/Michelle_orb_video.json.sequence.json
@@ -344,7 +344,7 @@
     }
   },
   "symbol_seq": "VQLLDADUUUKSWSAPIHWWEISAASBTRHVREADWLIESSSRKMEADADNNWPOSWCADLEV",
-  "symbol_seq_enhanced": "Pink/Magenta↑ Unknown↓ Unknown↓ Unknown Blue↑ Yellow↑ Yellow↓ Yellow↑ Yellow Unknown↑ Unknown Yellow Unknown↓ Unknown Yellow Unknown Yellow↑ Yellow↑ Unknown↓ Yellow↑ Pink/Magenta↓ Pink/Magenta Unknown↓ Unknown↓ Yellow↓ Yellow Pink/Magenta↓ Yellow↓ Unknown↓ Yellow↑ Yellow↑ Unknown↑ Yellow↓ Unknown Unknown↓ Unknown Unknown Yellow↓ Unknown Blue↑ Unknown↑ Yellow↑ Yellow↑ Blue Blue Yellow Yellow Blue↑ Unknown Yellow Blue↑ Yellow↓ Unknown Unknown Pink/Magenta↓",
+  "symbol_seq_enhanced": "Pink/Magenta↑ V0 Unknown↓ V0 Unknown↓ V0 Unknown V0 Blue↑ V0 Yellow↑ V0 Yellow↓ V0 Yellow↑ V0 Yellow V0 Unknown↑ V0 Unknown V0 Yellow V0 Unknown↓ V0 Unknown V0 Yellow V0 Unknown V0 Yellow↑ V0 Yellow↑ V0 Unknown↓ V0 Yellow↑ V0 Pink/Magenta↓ V0 Pink/Magenta V0 Unknown↓ V0 Unknown↓ V0 Yellow↓ V0 Yellow V0 Pink/Magenta↓ V0 Yellow↓ V0 Unknown↓ V0 Yellow↑ V0 Yellow↑ V0 Unknown↑ V0 Yellow↓ V0 Unknown V0 Unknown↓ V0 Unknown V0 Unknown V0 Yellow↓ V0 Unknown V0 Blue↑ V0 Unknown↑ V0 Yellow↑ V0 Yellow↑ V0 Blue V0 Blue V0 Yellow V0 Yellow V0 Blue↑ V0 Unknown V0 Yellow V0 Blue↑ V0 Yellow↓ V0 Unknown V0 Unknown V0 Pink/Magenta↓ V0",
   "binary_seq": "1110000001101000000011110010000100111000100000001000001",
   "v_threshold": 0.454,
   "events": [
@@ -358,7 +358,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "Michelle_orb_video_e000_000250_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e000_000250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 1,
@@ -370,7 +378,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "Michelle_orb_video_e001_000750_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e001_000750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 2,
@@ -382,7 +398,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "Michelle_orb_video_e002_001250_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e002_001250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 3,
@@ -394,7 +418,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "Michelle_orb_video_e003_001750_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e003_001750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 4,
@@ -406,7 +437,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "Michelle_orb_video_e004_002250_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e004_002250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 5,
@@ -418,7 +457,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 5,
-      "thumb_obj": "Michelle_orb_video_e005_002750_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e005_002750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 6,
@@ -430,7 +477,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "Michelle_orb_video_e006_003250_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e006_003250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 7,
@@ -442,7 +497,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "Michelle_orb_video_e007_003750_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e007_003750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 8,
@@ -454,7 +517,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "Michelle_orb_video_e008_004250_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e008_004250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 9,
@@ -466,7 +536,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "Michelle_orb_video_e009_004750_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e009_004750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 10,
@@ -478,7 +556,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "Michelle_orb_video_e010_005250_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e010_005250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 11,
@@ -490,7 +575,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "Michelle_orb_video_e011_005750_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e011_005750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 12,
@@ -502,7 +594,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "Michelle_orb_video_e012_006250_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e012_006250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 13,
@@ -514,7 +614,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 9,
-      "thumb_obj": "Michelle_orb_video_e013_006750_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e013_006750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 14,
@@ -526,7 +633,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "Michelle_orb_video_e014_007250_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e014_007250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 15,
@@ -538,7 +652,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 0,
-      "thumb_obj": "Michelle_orb_video_e015_007750_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e015_007750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 16,
@@ -550,7 +671,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "Michelle_orb_video_e016_008250_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e016_008250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 17,
@@ -562,7 +691,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "Michelle_orb_video_e017_008750_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e017_008750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 18,
@@ -574,7 +711,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "Michelle_orb_video_e018_009250_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e018_009250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 19,
@@ -586,7 +731,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "Michelle_orb_video_e019_009750_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e019_009750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 20,
@@ -598,7 +751,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 63,
-      "thumb_obj": "Michelle_orb_video_e020_010250_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e020_010250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 21,
@@ -610,7 +771,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 70,
-      "thumb_obj": "Michelle_orb_video_e021_010750_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e021_010750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 22,
@@ -622,7 +790,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "Michelle_orb_video_e022_011250_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e022_011250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 23,
@@ -634,7 +810,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 72,
-      "thumb_obj": "Michelle_orb_video_e023_011750_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e023_011750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 24,
@@ -646,7 +830,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "Michelle_orb_video_e024_012250_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e024_012250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 25,
@@ -658,7 +850,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "Michelle_orb_video_e025_012750_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e025_012750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 26,
@@ -670,7 +869,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "Michelle_orb_video_e026_013250_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e026_013250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 27,
@@ -682,7 +889,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "Michelle_orb_video_e027_013750_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e027_013750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 28,
@@ -694,7 +909,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "Michelle_orb_video_e028_014250_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e028_014250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 29,
@@ -706,7 +929,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 5,
-      "thumb_obj": "Michelle_orb_video_e029_014750_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e029_014750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 30,
@@ -718,7 +949,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "Michelle_orb_video_e030_015250_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e030_015250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 31,
@@ -730,7 +969,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "Michelle_orb_video_e031_015750_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e031_015750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 32,
@@ -742,7 +989,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "Michelle_orb_video_e032_016250_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e032_016250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 33,
@@ -754,7 +1009,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "Michelle_orb_video_e033_016750_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e033_016750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 34,
@@ -766,7 +1028,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "Michelle_orb_video_e034_017250_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e034_017250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 35,
@@ -778,7 +1048,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "Michelle_orb_video_e035_017750_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e035_017750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 36,
@@ -790,7 +1067,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "Michelle_orb_video_e036_018250_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e036_018250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 37,
@@ -802,7 +1086,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "Michelle_orb_video_e037_018750_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e037_018750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 38,
@@ -814,7 +1106,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "Michelle_orb_video_e038_019250_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e038_019250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 39,
@@ -826,7 +1125,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "Michelle_orb_video_e039_019750_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e039_019750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 40,
@@ -838,7 +1145,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "Michelle_orb_video_e040_020250_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e040_020250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 41,
@@ -850,7 +1165,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 5,
-      "thumb_obj": "Michelle_orb_video_e041_020750_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e041_020750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 42,
@@ -862,7 +1185,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 5,
-      "thumb_obj": "Michelle_orb_video_e042_021250_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e042_021250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 43,
@@ -874,7 +1205,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "Michelle_orb_video_e043_021750_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e043_021750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 44,
@@ -886,7 +1224,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "Michelle_orb_video_e044_022250_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e044_022250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 45,
@@ -898,7 +1243,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "Michelle_orb_video_e045_022750_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e045_022750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 46,
@@ -910,7 +1262,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "Michelle_orb_video_e046_023250_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e046_023250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 47,
@@ -922,7 +1281,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "Michelle_orb_video_e047_023750_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e047_023750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 48,
@@ -934,7 +1301,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "Michelle_orb_video_e048_024250_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e048_024250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 49,
@@ -946,7 +1320,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "Michelle_orb_video_e049_024750_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e049_024750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 50,
@@ -958,7 +1339,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "Michelle_orb_video_e050_025250_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e050_025250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 51,
@@ -970,7 +1359,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 5,
-      "thumb_obj": "Michelle_orb_video_e051_025750_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e051_025750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 52,
@@ -982,7 +1379,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "Michelle_orb_video_e052_026250_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e052_026250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 53,
@@ -994,7 +1398,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "Michelle_orb_video_e053_026750_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e053_026750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 54,
@@ -1006,11 +1417,19 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "Michelle_orb_video_e054_027150_obj.jpg"
+      "thumb_obj": "Michelle_orb_video_e054_027150_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     }
   ],
   "cycles": [
-    "Pink/Magenta↑ Unknown↓ Unknown↓ Unknown Blue↑ Yellow↑ Yellow↓ Yellow↑ Yellow Unknown↑ Unknown Yellow Unknown↓ Unknown Yellow Unknown Yellow↑ Yellow↑ Unknown↓ Yellow↑ Pink/Magenta↓ Pink/Magenta Unknown↓ Unknown↓ Yellow↓ Yellow Pink/Magenta↓ Yellow↓ Unknown↓ Yellow↑ Yellow↑ Unknown↑ Yellow↓ Unknown Unknown↓ Unknown Unknown Yellow↓ Unknown Blue↑ Unknown↑ Yellow↑ Yellow↑ Blue Blue Yellow Yellow Blue↑ Unknown Yellow Blue↑ Yellow↓ Unknown Unknown Pink/Magenta↓"
+    "Pink/Magenta↑ V0 Unknown↓ V0 Unknown↓ V0 Unknown V0 Blue↑ V0 Yellow↑ V0 Yellow↓ V0 Yellow↑ V0 Yellow V0 Unknown↑ V0 Unknown V0 Yellow V0 Unknown↓ V0 Unknown V0 Yellow V0 Unknown V0 Yellow↑ V0 Yellow↑ V0 Unknown↓ V0 Yellow↑ V0 Pink/Magenta↓ V0 Pink/Magenta V0 Unknown↓ V0 Unknown↓ V0 Yellow↓ V0 Yellow V0 Pink/Magenta↓ V0 Yellow↓ V0 Unknown↓ V0 Yellow↑ V0 Yellow↑ V0 Unknown↑ V0 Yellow↓ V0 Unknown V0 Unknown↓ V0 Unknown V0 Unknown V0 Yellow↓ V0 Unknown V0 Blue↑ V0 Unknown↑ V0 Yellow↑ V0 Yellow↑ V0 Blue V0 Blue V0 Yellow V0 Yellow V0 Blue↑ V0 Unknown V0 Yellow V0 Blue↑ V0 Yellow↓ V0 Unknown V0 Unknown V0 Pink/Magenta↓ V0"
   ],
   "clustering": {
     "eps": 0.34,

--- a/public/sequences_merge/v12044gd0000d21um37og65quktep0s0.json.sequence.json
+++ b/public/sequences_merge/v12044gd0000d21um37og65quktep0s0.json.sequence.json
@@ -259,7 +259,7 @@
     }
   },
   "symbol_seq": "AXAHAETAEAIABGAADAKAKBJAFABTJASFMAIZAST",
-  "symbol_seq_enhanced": "Unknown↓ Unknown↑ Blue↑ Pink/Magenta Blue Pink/Magenta↑ Pink/Magenta↑ Blue Pink/Magenta↑ Blue↑ Pink/Magenta↑ Pink/Magenta Blue Blue Pink/Magenta↓ Pink/Magenta Pink/Magenta Blue↑ Unknown↑ Blue↑ Blue↑ Pink/Magenta↑ Blue Unknown↓ Pink/Magenta",
+  "symbol_seq_enhanced": "Unknown↓ V0 Unknown↑ V0 Blue↑ V0 Pink/Magenta V0 Blue V0 Pink/Magenta↑ V0 Pink/Magenta↑ V0 Blue V0 Pink/Magenta↑ V0 Blue↑ V0 Pink/Magenta↑ V0 Pink/Magenta V0 Blue V0 Blue V0 Pink/Magenta↓ V0 Pink/Magenta V0 Pink/Magenta V0 Blue↑ V0 Unknown↑ V0 Blue↑ V0 Blue↑ V0 Pink/Magenta↑ V0 Blue V0 Unknown↓ V0 Pink/Magenta V0",
   "binary_seq": "1011100101000000001010010",
   "v_threshold": 0.544,
   "events": [
@@ -273,7 +273,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 50,
-      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e000_000250_obj.jpg"
+      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e000_000250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 1,
@@ -285,7 +293,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 31,
-      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e001_000750_obj.jpg"
+      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e001_000750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 2,
@@ -297,7 +313,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 34,
-      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e002_001250_obj.jpg"
+      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e002_001250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 3,
@@ -309,7 +333,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e003_001750_obj.jpg"
+      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e003_001750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 4,
@@ -321,7 +352,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 34,
-      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e004_002250_obj.jpg"
+      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e004_002250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 5,
@@ -333,7 +371,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 67,
-      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e005_002750_obj.jpg"
+      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e005_002750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 6,
@@ -345,7 +391,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 44,
-      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e006_003250_obj.jpg"
+      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e006_003250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 7,
@@ -357,7 +411,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e007_003750_obj.jpg"
+      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e007_003750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 8,
@@ -369,7 +430,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 70,
-      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e008_004250_obj.jpg"
+      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e008_004250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 9,
@@ -381,7 +450,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e009_004750_obj.jpg"
+      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e009_004750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 10,
@@ -393,7 +470,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 29,
-      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e010_005250_obj.jpg"
+      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e010_005250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 11,
@@ -405,7 +490,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 29,
-      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e011_005750_obj.jpg"
+      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e011_005750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 12,
@@ -417,7 +509,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e012_006250_obj.jpg"
+      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e012_006250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 13,
@@ -429,7 +528,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e013_006750_obj.jpg"
+      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e013_006750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 14,
@@ -441,7 +547,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 54,
-      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e014_007250_obj.jpg"
+      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e014_007250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 15,
@@ -453,7 +567,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 44,
-      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e015_007750_obj.jpg"
+      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e015_007750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 16,
@@ -465,7 +586,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e016_008250_obj.jpg"
+      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e016_008250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 17,
@@ -477,7 +605,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e017_008750_obj.jpg"
+      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e017_008750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 18,
@@ -489,7 +625,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 64,
-      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e018_009250_obj.jpg"
+      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e018_009250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 19,
@@ -501,7 +645,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e019_009750_obj.jpg"
+      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e019_009750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 20,
@@ -513,7 +665,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e020_010250_obj.jpg"
+      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e020_010250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 21,
@@ -525,7 +685,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 67,
-      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e021_010750_obj.jpg"
+      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e021_010750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 22,
@@ -537,7 +705,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 49,
-      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e022_011250_obj.jpg"
+      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e022_011250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 23,
@@ -549,7 +724,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 64,
-      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e023_011750_obj.jpg"
+      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e023_011750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 24,
@@ -561,11 +744,18 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e024_012250_obj.jpg"
+      "thumb_obj": "v12044gd0000d21um37og65quktep0s0_e024_012250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     }
   ],
   "cycles": [
-    "Unknown↓ Unknown↑ Blue↑ Pink/Magenta Blue Pink/Magenta↑ Pink/Magenta↑ Blue Pink/Magenta↑ Blue↑ Pink/Magenta↑ Pink/Magenta Blue Blue Pink/Magenta↓ Pink/Magenta Pink/Magenta Blue↑ Unknown↑ Blue↑ Blue↑ Pink/Magenta↑ Blue Unknown↓ Pink/Magenta"
+    "Unknown↓ V0 Unknown↑ V0 Blue↑ V0 Pink/Magenta V0 Blue V0 Pink/Magenta↑ V0 Pink/Magenta↑ V0 Blue V0 Pink/Magenta↑ V0 Blue↑ V0 Pink/Magenta↑ V0 Pink/Magenta V0 Blue V0 Blue V0 Pink/Magenta↓ V0 Pink/Magenta V0 Pink/Magenta V0 Blue↑ V0 Unknown↑ V0 Blue↑ V0 Blue↑ V0 Pink/Magenta↑ V0 Blue V0 Unknown↓ V0 Pink/Magenta V0"
   ],
   "clustering": {
     "eps": 0.34,

--- a/public/sequences_merge/v12044gd0000d2hlm8fog65pe6sb3vm0.json.sequence.json
+++ b/public/sequences_merge/v12044gd0000d2hlm8fog65pe6sb3vm0.json.sequence.json
@@ -344,7 +344,7 @@
     }
   },
   "symbol_seq": "DJ_AAD_AR_DD_DDANAMDDAUAUZAPUAVAEBRBRDDD_NNUGAAAAMMACACDD_SOBANCVPFDDDUMMMAEDZDAJMMAQDZMAGZAEDZAVWDADLAFM",
-  "symbol_seq_enhanced": "Blue↑ Blue↓ Pink/Magenta↓ Pink/Magenta Blue↑ Blue↓ Unknown Blue↓ Blue↑ Blue↑ Blue↑ Blue↑ Blue↑ Unknown↓ Unknown Blue↑ Blue↑ Green Green Blue↑ Unknown Yellow Unknown Blue↓ Pink/Magenta↓ Pink/Magenta↓ Blue↑ Blue↑ Blue↑ Green↓ Blue↓ Blue↓ Yellow↓ Blue↓ Pink/Magenta↑ Pink/Magenta↑ Blue Blue Pink/Magenta↑ Pink/Magenta↑ Blue↑ Blue↑ Yellow↓ Pink/Magenta↓ Blue Unknown Blue Blue Pink/Magenta↑ Yellow Blue Blue↑ Blue↑ Blue↑ Yellow↑ Blue Blue Blue Blue↑ Blue↑ Blue↑ Blue Green↓ Blue↓ Blue↓ Green↑ Blue Unknown↓ Blue Pink/Magenta Unknown↑ Blue Blue↑ Blue↑ Unknown Yellow↓ Blue↑ Yellow↓ Unknown Pink/Magenta↑ Blue",
+  "symbol_seq_enhanced": "Blue↑ V0 Blue↓ V0 Pink/Magenta↓ V0 Pink/Magenta V0 Blue↑ V0 Blue↓ V0 Unknown V0 Blue↓ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Unknown↓ V0 Unknown V0 Blue↑ V0 Blue↑ V0 Green V0 Green V0 Blue↑ V0 Unknown V0 Yellow V0 Unknown V0 Blue↓ V0 Pink/Magenta↓ V0 Pink/Magenta↓ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Green↓ V0 Blue↓ V0 Blue↓ V0 Yellow↓ V0 Blue↓ V0 Pink/Magenta↑ V0 Pink/Magenta↑ V0 Blue V0 Blue V0 Pink/Magenta↑ V0 Pink/Magenta↑ V0 Blue↑ V0 Blue↑ V0 Yellow↓ V0 Pink/Magenta↓ V0 Blue V0 Unknown V0 Blue V0 Blue V0 Pink/Magenta↑ V0 Yellow V0 Blue V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Yellow↑ V0 Blue V0 Blue V0 Blue V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue V0 Green↓ V0 Blue↓ V0 Blue↓ V0 Green↑ V0 Blue V0 Unknown↓ V0 Blue V0 Pink/Magenta V0 Unknown↑ V0 Blue V0 Blue↑ V0 Blue↑ V0 Unknown V0 Yellow↓ V0 Blue↑ V0 Yellow↓ V0 Unknown V0 Pink/Magenta↑ V0 Blue V0",
   "binary_seq": "100010001101100110000000111110000100001111000000000111000001000000000000100010010",
   "v_threshold": 0.45199999999999996,
   "events": [
@@ -358,7 +358,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e000_000250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e000_000250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 1,
@@ -370,7 +378,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e001_000750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e001_000750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 2,
@@ -382,7 +398,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": -6,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e002_001250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e002_001250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 3,
@@ -394,7 +418,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 70,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e003_001750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e003_001750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 4,
@@ -406,7 +437,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e004_002250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e004_002250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 5,
@@ -418,7 +457,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": -1,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e005_002750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e005_002750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 6,
@@ -430,7 +477,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 42,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e006_003250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e006_003250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 7,
@@ -442,7 +496,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": -1,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e007_003750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e007_003750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 8,
@@ -454,7 +516,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e008_004250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e008_004250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 9,
@@ -466,7 +536,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e009_004750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e009_004750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 10,
@@ -478,7 +556,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": -1,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e010_005250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e010_005250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 11,
@@ -490,7 +576,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e011_005750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e011_005750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 12,
@@ -502,7 +596,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e012_006250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e012_006250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 13,
@@ -514,7 +616,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 27,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e013_006750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e013_006750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 14,
@@ -526,7 +636,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 7,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e014_007250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e014_007250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 15,
@@ -538,7 +655,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e015_007750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e015_007750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 16,
@@ -550,7 +675,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e016_008250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e016_008250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 17,
@@ -562,7 +695,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 56,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e017_008750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e017_008750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 18,
@@ -574,7 +714,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 56,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e018_009250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e018_009250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 19,
@@ -586,7 +733,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 49,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e019_009750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e019_009750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 20,
@@ -598,7 +753,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 9,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e020_010250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e020_010250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 21,
@@ -610,7 +772,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e021_010750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e021_010750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 22,
@@ -622,7 +791,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 53,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e022_011250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e022_011250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 23,
@@ -634,7 +810,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 34,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e023_011750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e023_011750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 24,
@@ -646,7 +830,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 16,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e024_012250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e024_012250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 25,
@@ -658,7 +850,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 16,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e025_012750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e025_012750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 26,
@@ -670,7 +870,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e026_013250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e026_013250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 27,
@@ -682,7 +890,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e027_013750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e027_013750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 28,
@@ -694,7 +910,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e028_014250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e028_014250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 29,
@@ -706,7 +930,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": -7,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e029_014750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e029_014750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 30,
@@ -718,7 +950,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e030_015250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e030_015250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 31,
@@ -730,7 +970,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e031_015750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e031_015750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 32,
@@ -742,7 +990,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e032_016250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e032_016250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 33,
@@ -754,7 +1010,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e033_016750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e033_016750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 34,
@@ -766,7 +1030,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 70,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e034_017250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e034_017250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 35,
@@ -778,7 +1050,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 70,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e035_017750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e035_017750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 36,
@@ -790,7 +1070,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e036_018250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e036_018250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 37,
@@ -802,7 +1089,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e037_018750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e037_018750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 38,
@@ -814,7 +1108,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 38,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e038_019250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e038_019250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 39,
@@ -826,7 +1128,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 38,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e039_019750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e039_019750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 40,
@@ -838,7 +1148,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e040_020250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e040_020250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 41,
@@ -850,7 +1168,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e041_020750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e041_020750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 42,
@@ -862,7 +1188,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": -8,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e042_021250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e042_021250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 43,
@@ -874,7 +1208,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 63,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e043_021750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e043_021750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 44,
@@ -886,7 +1228,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e044_022250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e044_022250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 45,
@@ -898,7 +1247,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 61,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e045_022750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e045_022750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 46,
@@ -910,7 +1266,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e046_023250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e046_023250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 47,
@@ -922,7 +1285,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e047_023750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e047_023750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 48,
@@ -934,7 +1304,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e048_024250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e048_024250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 49,
@@ -946,7 +1324,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e049_024750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e049_024750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 50,
@@ -958,7 +1343,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e050_025250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e050_025250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 51,
@@ -970,7 +1362,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e051_025750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e051_025750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 52,
@@ -982,7 +1382,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e052_026250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e052_026250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 53,
@@ -994,7 +1402,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e053_026750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e053_026750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 54,
@@ -1006,7 +1422,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e054_027250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e054_027250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 55,
@@ -1018,7 +1442,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e055_027750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e055_027750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 56,
@@ -1030,7 +1461,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e056_028250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e056_028250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 57,
@@ -1042,7 +1480,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e057_028750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e057_028750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 58,
@@ -1054,7 +1499,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 34,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e058_029250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e058_029250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 59,
@@ -1066,7 +1519,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e059_029750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e059_029750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 60,
@@ -1078,7 +1539,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 49,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e060_030250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e060_030250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 61,
@@ -1090,7 +1559,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e061_030750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e061_030750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 62,
@@ -1102,7 +1578,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 24,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e062_031250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e062_031250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 63,
@@ -1114,7 +1598,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e063_031750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e063_031750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 64,
@@ -1126,7 +1618,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e064_032250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e064_032250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 65,
@@ -1138,7 +1638,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 65,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e065_032750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e065_032750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 66,
@@ -1150,7 +1658,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e066_033250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e066_033250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 67,
@@ -1162,7 +1677,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 49,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e067_033750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e067_033750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 68,
@@ -1174,7 +1697,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e068_034250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e068_034250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 69,
@@ -1186,7 +1716,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 26,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e069_034750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e069_034750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 70,
@@ -1198,7 +1735,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 49,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e070_035250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e070_035250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 71,
@@ -1210,7 +1755,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 34,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e071_035750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e071_035750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 72,
@@ -1222,7 +1774,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e072_036250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e072_036250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 73,
@@ -1234,7 +1794,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 49,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e073_036750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e073_036750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 74,
@@ -1246,7 +1814,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 53,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e074_037250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e074_037250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 75,
@@ -1258,7 +1833,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e075_037750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e075_037750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 76,
@@ -1270,7 +1853,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e076_038250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e076_038250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 77,
@@ -1282,7 +1873,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 5,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e077_038750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e077_038750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 78,
@@ -1294,7 +1893,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e078_039250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e078_039250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 79,
@@ -1306,7 +1912,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 54,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e079_039750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e079_039750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 80,
@@ -1318,11 +1932,18 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e080_040045_obj.jpg"
+      "thumb_obj": "v12044gd0000d2hlm8fog65pe6sb3vm0_e080_040045_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     }
   ],
   "cycles": [
-    "Blue↑ Blue↓ Pink/Magenta↓ Pink/Magenta Blue↑ Blue↓ Unknown Blue↓ Blue↑ Blue↑ Blue↑ Blue↑ Blue↑ Unknown↓ Unknown Blue↑ Blue↑ Green Green Blue↑ Unknown Yellow Unknown Blue↓ Pink/Magenta↓ Pink/Magenta↓ Blue↑ Blue↑ Blue↑ Green↓ Blue↓ Blue↓ Yellow↓ Blue↓ Pink/Magenta↑ Pink/Magenta↑ Blue Blue Pink/Magenta↑ Pink/Magenta↑ Blue↑ Blue↑ Yellow↓ Pink/Magenta↓ Blue Unknown Blue Blue Pink/Magenta↑ Yellow Blue Blue↑ Blue↑ Blue↑ Yellow↑ Blue Blue Blue Blue↑ Blue↑ Blue↑ Blue Green↓ Blue↓ Blue↓ Green↑ Blue Unknown↓ Blue Pink/Magenta Unknown↑ Blue Blue↑ Blue↑ Unknown Yellow↓ Blue↑ Yellow↓ Unknown Pink/Magenta↑ Blue"
+    "Blue↑ V0 Blue↓ V0 Pink/Magenta↓ V0 Pink/Magenta V0 Blue↑ V0 Blue↓ V0 Unknown V0 Blue↓ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Unknown↓ V0 Unknown V0 Blue↑ V0 Blue↑ V0 Green V0 Green V0 Blue↑ V0 Unknown V0 Yellow V0 Unknown V0 Blue↓ V0 Pink/Magenta↓ V0 Pink/Magenta↓ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Green↓ V0 Blue↓ V0 Blue↓ V0 Yellow↓ V0 Blue↓ V0 Pink/Magenta↑ V0 Pink/Magenta↑ V0 Blue V0 Blue V0 Pink/Magenta↑ V0 Pink/Magenta↑ V0 Blue↑ V0 Blue↑ V0 Yellow↓ V0 Pink/Magenta↓ V0 Blue V0 Unknown V0 Blue V0 Blue V0 Pink/Magenta↑ V0 Yellow V0 Blue V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Yellow↑ V0 Blue V0 Blue V0 Blue V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue V0 Green↓ V0 Blue↓ V0 Blue↓ V0 Green↑ V0 Blue V0 Unknown↓ V0 Blue V0 Pink/Magenta V0 Unknown↑ V0 Blue V0 Blue↑ V0 Blue↑ V0 Unknown V0 Yellow↓ V0 Blue↑ V0 Yellow↓ V0 Unknown V0 Pink/Magenta↑ V0 Blue V0"
   ],
   "clustering": {
     "eps": 0.34,

--- a/public/sequences_merge/v12044gd0000d2husv7og65snaorfbcg.json.sequence.json
+++ b/public/sequences_merge/v12044gd0000d2husv7og65snaorfbcg.json.sequence.json
@@ -361,7 +361,7 @@
     }
   },
   "symbol_seq": "ATACIANANKKPRWAALLEKALVADVKIIAEKSAJEEBAAJJFAAAALLLAJDFFFFAAADFKQIZVADDBBABASJJCWBUUYAPAPL",
-  "symbol_seq_enhanced": "Unknown Pink/Magenta Yellow Unknown Unknown↓ Unknown↑ Unknown↑ Yellow↓ Yellow↓ Yellow↑ Pink/Magenta Unknown↓ Unknown↓ Unknown↑ Unknown↓ Green Pink/Magenta↓ Yellow↓ Pink/Magenta Unknown↓ Yellow↓ Yellow↓ Blue Unknown↑ Unknown↓ Green↑ Unknown Unknown↓ Unknown↓ Blue Blue Blue Blue Blue Blue Blue Blue Unknown↑ Unknown↑ Unknown↑ Green Blue Blue Blue Blue Blue Blue Blue Blue Blue Blue Unknown↓ Unknown↑ Yellow Blue↓ Pink/Magenta↑ Blue Blue Blue Blue Blue Blue Blue Unknown↑ Blue Blue Blue Yellow↓ Blue Yellow Yellow Unknown Unknown↓ Unknown↓ Unknown↑",
+  "symbol_seq_enhanced": "Unknown V0 Pink/Magenta V0 Yellow V0 Unknown V0 Unknown↓ V0 Unknown↑ V0 Unknown↑ V0 Yellow↓ V0 Yellow↓ V0 Yellow↑ V0 Pink/Magenta V0 Unknown↓ V0 Unknown↓ V0 Unknown↑ V0 Unknown↓ V0 Green V0 Pink/Magenta↓ V0 Yellow↓ V0 Pink/Magenta V0 Unknown↓ V0 Yellow↓ V0 Yellow↓ V0 Blue V0 Unknown↑ V0 Unknown↓ V0 Green↑ V0 Unknown V0 Unknown↓ V0 Unknown↓ V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Green V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Unknown↓ V0 Unknown↑ V0 Yellow V0 Blue↓ V0 Pink/Magenta↑ V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Unknown↑ V0 Blue V0 Blue V0 Blue V0 Yellow↓ V0 Blue V0 Yellow V0 Yellow V0 Unknown V0 Unknown↓ V0 Unknown↓ V0 Unknown↑ V0",
   "binary_seq": "000000000000000010000000000001001111100111111111110000011111111000101000000",
   "v_threshold": 0.598,
   "events": [
@@ -375,7 +375,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 32,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e051_051500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e051_051500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 52,
@@ -387,7 +394,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 38,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e052_052500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e052_052500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 53,
@@ -399,7 +413,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e053_053500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e053_053500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 54,
@@ -411,7 +432,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 27,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e054_054500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e054_054500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 55,
@@ -423,7 +451,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 27,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e055_055500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e055_055500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 56,
@@ -435,7 +471,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e056_056500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e056_056500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 57,
@@ -447,7 +491,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e057_057500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e057_057500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 58,
@@ -459,7 +511,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e058_058500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e058_058500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 59,
@@ -471,7 +531,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e059_059500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e059_059500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 60,
@@ -483,7 +551,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e060_060500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e060_060500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 61,
@@ -495,7 +571,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 70,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e061_061500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e061_061500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 62,
@@ -507,7 +590,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e062_062500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e062_062500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 63,
@@ -519,7 +610,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e063_063500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e063_063500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 64,
@@ -531,7 +630,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e064_064500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e064_064500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 65,
@@ -543,7 +650,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e065_065500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e065_065500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 66,
@@ -555,7 +670,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 1,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e066_066500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e066_066500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 67,
@@ -567,7 +689,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e067_067500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e067_067500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 68,
@@ -579,7 +709,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 5,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e068_068500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e068_068500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 69,
@@ -591,7 +729,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e069_069500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e069_069500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 70,
@@ -603,7 +748,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e070_070500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e070_070500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 71,
@@ -615,7 +768,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e071_071500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e071_071500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 72,
@@ -627,7 +788,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e072_072500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e072_072500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 73,
@@ -639,7 +808,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 34,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e073_073500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e073_073500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 74,
@@ -651,7 +827,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e074_074500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e074_074500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 75,
@@ -663,7 +847,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e075_075500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e075_075500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 76,
@@ -675,7 +867,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 24,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e076_076500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e076_076500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 77,
@@ -687,7 +887,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e077_077500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e077_077500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 78,
@@ -699,7 +906,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e078_078500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e078_078500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 79,
@@ -711,7 +926,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 61,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e079_079500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e079_079500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 80,
@@ -723,7 +946,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e080_080500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e080_080500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 81,
@@ -735,7 +965,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e081_081500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e081_081500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 82,
@@ -747,7 +984,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e082_082500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e082_082500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 83,
@@ -759,7 +1003,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e083_083500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e083_083500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 84,
@@ -771,7 +1022,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e084_084500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e084_084500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 85,
@@ -783,7 +1041,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e085_085500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e085_085500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 86,
@@ -795,7 +1060,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e086_086500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e086_086500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 87,
@@ -807,7 +1079,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e087_087500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e087_087500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 88,
@@ -819,7 +1098,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e088_088500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e088_088500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 89,
@@ -831,7 +1118,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e089_089500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e089_089500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 90,
@@ -843,7 +1138,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e090_090500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e090_090500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 91,
@@ -855,7 +1158,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 24,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e091_091500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e091_091500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 92,
@@ -867,7 +1177,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e092_092500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e092_092500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 93,
@@ -879,7 +1196,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e093_093500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e093_093500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 94,
@@ -891,7 +1215,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e094_094500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e094_094500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 95,
@@ -903,7 +1234,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e095_095500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e095_095500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 96,
@@ -915,7 +1253,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e096_096500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e096_096500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 97,
@@ -927,7 +1272,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e097_097500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e097_097500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 98,
@@ -939,7 +1291,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e098_098500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e098_098500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 99,
@@ -951,7 +1310,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e099_099500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e099_099500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 100,
@@ -963,7 +1329,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e100_100500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e100_100500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 101,
@@ -975,7 +1348,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e101_101500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e101_101500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 102,
@@ -987,7 +1367,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e102_102500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e102_102500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 103,
@@ -999,7 +1387,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e103_103500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e103_103500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 104,
@@ -1011,7 +1407,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e104_104500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e104_104500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 105,
@@ -1023,7 +1426,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 49,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e105_105500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e105_105500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 106,
@@ -1035,7 +1446,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e106_106500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e106_106500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 107,
@@ -1047,7 +1466,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e107_107500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e107_107500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 108,
@@ -1059,7 +1485,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e108_108500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e108_108500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 109,
@@ -1071,7 +1504,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e109_109500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e109_109500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 110,
@@ -1083,7 +1523,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e110_110500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e110_110500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 111,
@@ -1095,7 +1542,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e111_111500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e111_111500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 112,
@@ -1107,7 +1561,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e112_112500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e112_112500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 113,
@@ -1119,7 +1580,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e113_113500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e113_113500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 114,
@@ -1131,7 +1599,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 64,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e114_114500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e114_114500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 115,
@@ -1143,7 +1619,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e115_115500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e115_115500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 116,
@@ -1155,7 +1638,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e116_116500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e116_116500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 117,
@@ -1167,7 +1657,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e117_117500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e117_117500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 118,
@@ -1179,7 +1676,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e118_118500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e118_118500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 119,
@@ -1191,7 +1696,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e119_119500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e119_119500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 120,
@@ -1203,7 +1715,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e120_120500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e120_120500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 121,
@@ -1215,7 +1734,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e121_121500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e121_121500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 122,
@@ -1227,7 +1753,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e122_122500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e122_122500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 123,
@@ -1239,7 +1772,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 9,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e123_123500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e123_123500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 124,
@@ -1251,7 +1792,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 9,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e124_124500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e124_124500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 125,
@@ -1263,11 +1812,19 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e125_125500_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg_e125_125500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     }
   ],
   "cycles": [
-    "Unknown Pink/Magenta Yellow Unknown Unknown↓ Unknown↑ Unknown↑ Yellow↓ Yellow↓ Yellow↑ Pink/Magenta Unknown↓ Unknown↓ Unknown↑ Unknown↓ Green Pink/Magenta↓ Yellow↓ Pink/Magenta Unknown↓ Yellow↓ Yellow↓ Blue Unknown↑ Unknown↓ Green↑ Unknown Unknown↓ Unknown↓ Blue Blue Blue Blue Blue Blue Blue Blue Unknown↑ Unknown↑ Unknown↑ Green Blue Blue Blue Blue Blue Blue Blue Blue Blue Blue Unknown↓ Unknown↑ Yellow Blue↓ Pink/Magenta↑ Blue Blue Blue Blue Blue Blue Blue Unknown↑ Blue Blue Blue Yellow↓ Blue Yellow Yellow Unknown Unknown↓ Unknown↓ Unknown↑"
+    "Unknown V0 Pink/Magenta V0 Yellow V0 Unknown V0 Unknown↓ V0 Unknown↑ V0 Unknown↑ V0 Yellow↓ V0 Yellow↓ V0 Yellow↑ V0 Pink/Magenta V0 Unknown↓ V0 Unknown↓ V0 Unknown↑ V0 Unknown↓ V0 Green V0 Pink/Magenta↓ V0 Yellow↓ V0 Pink/Magenta V0 Unknown↓ V0 Yellow↓ V0 Yellow↓ V0 Blue V0 Unknown↑ V0 Unknown↓ V0 Green↑ V0 Unknown V0 Unknown↓ V0 Unknown↓ V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Green V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Unknown↓ V0 Unknown↑ V0 Yellow V0 Blue↓ V0 Pink/Magenta↑ V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Unknown↑ V0 Blue V0 Blue V0 Blue V0 Yellow↓ V0 Blue V0 Yellow V0 Yellow V0 Unknown V0 Unknown↓ V0 Unknown↓ V0 Unknown↑ V0"
   ],
   "clustering": {
     "eps": 0.34,

--- a/public/sequences_merge/v12044gd0000d2husv7og65snaorfbcg.mp4.json.sequence.json
+++ b/public/sequences_merge/v12044gd0000d2husv7og65snaorfbcg.mp4.json.sequence.json
@@ -429,7 +429,7 @@
     }
   },
   "symbol_seq": "AAAXAYACAQSRRANKEKKQPHAJHAM_AWJPPERAKAKELAHELAAPLLLLVAJQHHPLIIFRKFWIRRADAKERFHHIQLIBZVYABAKAJIDATADBAARABCASGGJALALCAAYWARNATAABACBAGLAQQQLAMIUQEIEEAIPTQAHAIAFABAAPARBADACIIADLABARLYMJTRVQVYYAHLAJAGJAKEPASAUAKAJEGBGCBAAC",
-  "symbol_seq_enhanced": "Pink/Magenta↓ Unknown Green↑ Pink/Magenta Green Unknown↓ Yellow Yellow Unknown↓ Unknown↑ Unknown↓ Unknown↑ Unknown↑ Unknown Yellow↓ Yellow↓ Green↓ Yellow Unknown↑ Unknown↑ Unknown Blue Yellow↓ Yellow↓ Unknown↓ Yellow Pink/Magenta↓ Pink/Magenta↓ Unknown↓ Unknown↑ Pink/Magenta Unknown Unknown↓ Pink/Magenta Yellow Unknown↑ Unknown↑ Unknown↑ Unknown↑ Pink/Magenta↑ Green Unknown↓ Yellow Yellow Yellow↑ Unknown Yellow Yellow Blue Yellow↓ Unknown Blue Yellow↑ Yellow Yellow↓ Yellow↓ Yellow Blue Unknown↑ Unknown↓ Yellow↓ Blue Yellow Yellow Yellow↑ Unknown↑ Unknown Yellow Blue Blue↓ Pink/Magenta↑ Unknown Blue Green Unknown Green Yellow Blue Unknown Yellow Blue Blue Unknown Blue Blue Blue Unknown↑ Blue Blue Blue Green↑ Green↑ Blue Blue Green↑ Yellow↓ Blue Yellow Blue Unknown↓ Blue Blue Blue Blue Blue Blue Blue Blue Unknown Blue Unknown↑ Unknown↑ Unknown↓ Unknown Unknown↓ Yellow↓ Yellow Unknown↓ Unknown↓ Yellow Unknown↓ Unknown↓ Pink/Magenta↓ Yellow↓ Pink/Magenta↓ Unknown↓ Unknown↓ Pink/Magenta↓ Pink/Magenta↑ Pink/Magenta↓ Blue Unknown↑ Unknown↓ Blue Blue Blue Pink/Magenta Yellow↓ Yellow↓ Blue Blue Unknown↓ Blue Blue Unknown Unknown↑ Unknown↑ Blue↓ Blue↑ Pink/Magenta↓ Yellow↓ Pink/Magenta Unknown↓ Pink/Magenta↓ Unknown Unknown Blue↑ Yellow↑ Unknown Green↓ Pink/Magenta Blue↓ Pink/Magenta↓ Unknown↑ Yellow↓ Unknown Green↑ Pink/Magenta Green↓ Unknown↑ Blue Blue Blue Blue Blue Blue Blue Blue",
+  "symbol_seq_enhanced": "Pink/Magenta↓ V0 Unknown V0 Green↑ V0 Pink/Magenta V0 Green V0 Unknown↓ V0 Yellow V0 Yellow V0 Unknown↓ V0 Unknown↑ V0 Unknown↓ V0 Unknown↑ V0 Unknown↑ V0 Unknown V0 Yellow↓ V0 Yellow↓ V0 Green↓ V0 Yellow V0 Unknown↑ V0 Unknown↑ V0 Unknown V0 Blue V0 Yellow↓ V0 Yellow↓ V0 Unknown↓ V0 Yellow V0 Pink/Magenta↓ V0 Pink/Magenta↓ V0 Unknown↓ V0 Unknown↑ V0 Pink/Magenta V0 Unknown V0 Unknown↓ V0 Pink/Magenta V0 Yellow V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Pink/Magenta↑ V0 Green V0 Unknown↓ V0 Yellow V0 Yellow V0 Yellow↑ V0 Unknown V0 Yellow V0 Yellow V0 Blue V0 Yellow↓ V0 Unknown V0 Blue V0 Yellow↑ V0 Yellow V0 Yellow↓ V0 Yellow↓ V0 Yellow V0 Blue V0 Unknown↑ V0 Unknown↓ V0 Yellow↓ V0 Blue V0 Yellow V0 Yellow V0 Yellow↑ V0 Unknown↑ V0 Unknown V0 Yellow V0 Blue V0 Blue↓ V0 Pink/Magenta↑ V0 Unknown V0 Blue V0 Green V0 Unknown V0 Green V0 Yellow V0 Blue V0 Unknown V0 Yellow V0 Blue V0 Blue V0 Unknown V0 Blue V0 Blue V0 Blue V0 Unknown↑ V0 Blue V0 Blue V0 Blue V0 Green↑ V0 Green↑ V0 Blue V0 Blue V0 Green↑ V0 Yellow↓ V0 Blue V0 Yellow V0 Blue V0 Unknown↓ V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Unknown V0 Blue V0 Unknown↑ V0 Unknown↑ V0 Unknown↓ V0 Unknown V0 Unknown↓ V0 Yellow↓ V0 Yellow V0 Unknown↓ V0 Unknown↓ V0 Yellow V0 Unknown↓ V0 Unknown↓ V0 Pink/Magenta↓ V0 Yellow↓ V0 Pink/Magenta↓ V0 Unknown↓ V0 Unknown↓ V0 Pink/Magenta↓ V0 Pink/Magenta↑ V0 Pink/Magenta↓ V0 Blue V0 Unknown↑ V0 Unknown↓ V0 Blue V0 Blue V0 Blue V0 Pink/Magenta V0 Yellow↓ V0 Yellow↓ V0 Blue V0 Blue V0 Unknown↓ V0 Blue V0 Blue V0 Unknown V0 Unknown↑ V0 Unknown↑ V0 Blue↓ V0 Blue↑ V0 Pink/Magenta↓ V0 Yellow↓ V0 Pink/Magenta V0 Unknown↓ V0 Pink/Magenta↓ V0 Unknown V0 Unknown V0 Blue↑ V0 Yellow↑ V0 Unknown V0 Green↓ V0 Pink/Magenta V0 Blue↓ V0 Pink/Magenta↓ V0 Unknown↑ V0 Yellow↓ V0 Unknown V0 Green↑ V0 Pink/Magenta V0 Green↓ V0 Unknown↑ V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0",
   "binary_seq": "0000000000000000000000000011100010000111100000001001000001110000000010111010011011111001100010001001110101110111000000000000000100101111000110111000000000000000000000000000011001",
   "v_threshold": 0.578,
   "events": [
@@ -443,7 +443,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 70,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e102_051250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e102_051250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 103,
@@ -455,7 +463,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 50,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e103_051750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e103_051750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 104,
@@ -467,7 +482,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 45,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e104_052250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e104_052250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 105,
@@ -479,7 +502,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 38,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e105_052750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e105_052750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 106,
@@ -491,7 +521,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 65,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e106_053250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e106_053250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 107,
@@ -503,7 +540,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e107_053750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e107_053750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 108,
@@ -515,7 +560,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e108_054250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e108_054250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 109,
@@ -527,7 +579,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e109_054750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e109_054750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 110,
@@ -539,7 +598,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 27,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e110_055250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e110_055250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 111,
@@ -551,7 +618,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e111_055750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e111_055750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 112,
@@ -563,7 +638,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e112_056250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e112_056250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 113,
@@ -575,7 +658,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e113_056750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e113_056750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 114,
@@ -587,7 +678,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e114_057250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e114_057250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 115,
@@ -599,7 +698,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e115_057750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e115_057750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 116,
@@ -611,7 +717,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e116_058250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e116_058250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 117,
@@ -623,7 +737,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e117_058750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e117_058750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 118,
@@ -635,7 +757,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 24,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e118_059250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e118_059250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 119,
@@ -647,7 +777,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e119_059700_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e119_059700_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 160,
@@ -659,7 +796,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 7,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e160_080250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e160_080250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 161,
@@ -671,7 +816,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": -2,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e161_080750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e161_080750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 162,
@@ -683,7 +836,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 58,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e162_081250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e162_081250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 163,
@@ -695,7 +855,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e163_081750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e163_081750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 164,
@@ -707,7 +874,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e164_082250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e164_082250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 165,
@@ -719,7 +894,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e165_082750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e165_082750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 166,
@@ -731,7 +914,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e166_083250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e166_083250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 167,
@@ -743,7 +934,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e167_083750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e167_083750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 168,
@@ -755,7 +953,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 29,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e168_084250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e168_084250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 169,
@@ -767,7 +973,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 29,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e169_084750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e169_084750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 170,
@@ -779,7 +993,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e170_085250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e170_085250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 171,
@@ -791,7 +1013,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e171_085750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e171_085750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 172,
@@ -803,7 +1033,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 31,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e172_086250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e172_086250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 173,
@@ -815,7 +1052,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e173_086750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e173_086750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 174,
@@ -827,7 +1071,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e174_087250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e174_087250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 175,
@@ -839,7 +1091,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 70,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e175_087750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e175_087750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 176,
@@ -851,7 +1110,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e176_088250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e176_088250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 177,
@@ -863,7 +1129,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e177_088750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e177_088750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 178,
@@ -875,7 +1149,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e178_089250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e178_089250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 179,
@@ -887,7 +1169,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e179_089750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e179_089750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 180,
@@ -899,7 +1189,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e180_090250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e180_090250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 181,
@@ -911,7 +1209,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e181_090750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e181_090750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 182,
@@ -923,7 +1229,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 24,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e182_091250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e182_091250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 183,
@@ -935,7 +1248,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e183_091750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e183_091750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 184,
@@ -947,7 +1268,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e184_092250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e184_092250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 185,
@@ -959,7 +1287,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e185_092750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e185_092750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 186,
@@ -971,7 +1306,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e186_093250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e186_093250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 187,
@@ -983,7 +1326,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e187_093750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e187_093750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 188,
@@ -995,7 +1345,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e188_094250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e188_094250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 189,
@@ -1007,7 +1364,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e189_094750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e189_094750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 190,
@@ -1019,7 +1383,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e190_095250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e190_095250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 191,
@@ -1031,7 +1402,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e191_095750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e191_095750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 192,
@@ -1043,7 +1422,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e192_096250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e192_096250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 193,
@@ -1055,7 +1441,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e193_096750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e193_096750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 194,
@@ -1067,7 +1460,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e194_097250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e194_097250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 195,
@@ -1079,7 +1480,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e195_097750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e195_097750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 196,
@@ -1091,7 +1499,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e196_098250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e196_098250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 197,
@@ -1103,7 +1519,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e197_098750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e197_098750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 198,
@@ -1115,7 +1539,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 5,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e198_099250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e198_099250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 199,
@@ -1127,7 +1558,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e199_099700_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e199_099700_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 200,
@@ -1139,7 +1577,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e200_100250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e200_100250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 201,
@@ -1151,7 +1597,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e201_100750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e201_100750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 202,
@@ -1163,7 +1617,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e202_101250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e202_101250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 203,
@@ -1175,7 +1637,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e203_101750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e203_101750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 204,
@@ -1187,7 +1656,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e204_102250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e204_102250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 205,
@@ -1199,7 +1675,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e205_102750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e205_102750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 206,
@@ -1211,7 +1694,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e206_103250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e206_103250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 207,
@@ -1223,7 +1714,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e207_103750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e207_103750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 208,
@@ -1235,7 +1734,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e208_104250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e208_104250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 209,
@@ -1247,7 +1753,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e209_104750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e209_104750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 210,
@@ -1259,7 +1772,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e210_105250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e210_105250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 211,
@@ -1271,7 +1791,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 49,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e211_105750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e211_105750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 212,
@@ -1283,7 +1811,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e212_106250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e212_106250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 213,
@@ -1295,7 +1831,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e213_106750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e213_106750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 214,
@@ -1307,7 +1850,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e214_107250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e214_107250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 215,
@@ -1319,7 +1869,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 61,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e215_107750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e215_107750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 216,
@@ -1331,7 +1888,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e216_108250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e216_108250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 217,
@@ -1343,7 +1907,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 24,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e217_108750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e217_108750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 218,
@@ -1355,7 +1926,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e218_109250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e218_109250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 219,
@@ -1367,7 +1945,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e219_109750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e219_109750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 220,
@@ -1379,7 +1964,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 32,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e220_110250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e220_110250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 221,
@@ -1391,7 +1983,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 5,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e221_110750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e221_110750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 222,
@@ -1403,7 +2002,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e222_111250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e222_111250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 223,
@@ -1415,7 +2021,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e223_111750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e223_111750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 224,
@@ -1427,7 +2040,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 42,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e224_112250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e224_112250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 225,
@@ -1439,7 +2059,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e225_112750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e225_112750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 226,
@@ -1451,7 +2078,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e226_113250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e226_113250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 227,
@@ -1463,7 +2097,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e227_113750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e227_113750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 228,
@@ -1475,7 +2116,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 64,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e228_114250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e228_114250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 229,
@@ -1487,7 +2136,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e229_114750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e229_114750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 230,
@@ -1499,7 +2155,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e230_115250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e230_115250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 231,
@@ -1511,7 +2174,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e231_115750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e231_115750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 232,
@@ -1523,7 +2193,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 1,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e232_116250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e232_116250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 233,
@@ -1535,7 +2213,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 1,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e233_116750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e233_116750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 234,
@@ -1547,7 +2233,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e234_117250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e234_117250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 235,
@@ -1559,7 +2252,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e235_117750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e235_117750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 236,
@@ -1571,7 +2271,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 45,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e236_118250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e236_118250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 237,
@@ -1583,7 +2291,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e237_118750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e237_118750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 238,
@@ -1595,7 +2311,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e238_119250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e238_119250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 239,
@@ -1607,7 +2330,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e239_119700_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e239_119700_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 280,
@@ -1619,7 +2349,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e280_140250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e280_140250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 281,
@@ -1631,7 +2368,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 32,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e281_140750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e281_140750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 282,
@@ -1643,7 +2388,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e282_141250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e282_141250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 283,
@@ -1655,7 +2407,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e283_141750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e283_141750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 284,
@@ -1667,7 +2426,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e284_142250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e284_142250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 285,
@@ -1679,7 +2445,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e285_142750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e285_142750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 286,
@@ -1691,7 +2464,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e286_143250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e286_143250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 287,
@@ -1703,7 +2483,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e287_143750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e287_143750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 288,
@@ -1715,7 +2502,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e288_144250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e288_144250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 289,
@@ -1727,7 +2521,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e289_144750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e289_144750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 290,
@@ -1739,7 +2540,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e290_145250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e290_145250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 291,
@@ -1751,7 +2559,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e291_145750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e291_145750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 292,
@@ -1763,7 +2578,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e292_146250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e292_146250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 293,
@@ -1775,7 +2598,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e293_146750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e293_146750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 294,
@@ -1787,7 +2618,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e294_147250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e294_147250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 295,
@@ -1799,7 +2638,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e295_147750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e295_147750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 296,
@@ -1811,7 +2657,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 7,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e296_148250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e296_148250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 297,
@@ -1823,7 +2677,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e297_148750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e297_148750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 298,
@@ -1835,7 +2697,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e298_149250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e298_149250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 299,
@@ -1847,7 +2716,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e299_149750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e299_149750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 300,
@@ -1859,7 +2736,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e300_150250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e300_150250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 301,
@@ -1871,7 +2756,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e301_150750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e301_150750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 302,
@@ -1883,7 +2775,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e302_151250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e302_151250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 303,
@@ -1895,7 +2795,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e303_151750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e303_151750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 304,
@@ -1907,7 +2815,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 67,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e304_152250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e304_152250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 305,
@@ -1919,7 +2835,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e305_152750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e305_152750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 306,
@@ -1931,7 +2855,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e306_153250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e306_153250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 307,
@@ -1943,7 +2875,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e307_153750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e307_153750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 308,
@@ -1955,7 +2895,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 31,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e308_154250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e308_154250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 309,
@@ -1967,7 +2915,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 67,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e309_154750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e309_154750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 310,
@@ -1979,7 +2935,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 54,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e310_155250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e310_155250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 311,
@@ -1991,7 +2955,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 44,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e311_155750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e311_155750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 312,
@@ -2003,7 +2975,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e312_156250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e312_156250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 313,
@@ -2015,7 +2994,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 9,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e313_156750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e313_156750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 314,
@@ -2027,7 +3014,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 42,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e314_157250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e314_157250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 315,
@@ -2039,7 +3034,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e315_157750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e315_157750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 316,
@@ -2051,7 +3053,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e316_158250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e316_158250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 317,
@@ -2063,7 +3072,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e317_158750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e317_158750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 318,
@@ -2075,7 +3091,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 38,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e318_159250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e318_159250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 319,
@@ -2087,7 +3110,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e319_159749_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e319_159749_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 320,
@@ -2099,7 +3130,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e320_160250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e320_160250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 321,
@@ -2111,7 +3150,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e321_160750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e321_160750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 322,
@@ -2123,7 +3169,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e322_161250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e322_161250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 323,
@@ -2135,7 +3188,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e323_161750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e323_161750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 324,
@@ -2147,7 +3208,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e324_162250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e324_162250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 325,
@@ -2159,7 +3227,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e325_162750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e325_162750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 326,
@@ -2171,7 +3246,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 42,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e326_163250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e326_163250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 327,
@@ -2183,7 +3265,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e327_163750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e327_163750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 328,
@@ -2195,7 +3285,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e328_164250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e328_164250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 329,
@@ -2207,7 +3305,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e329_164750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e329_164750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 330,
@@ -2219,7 +3325,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e330_165250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e330_165250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 331,
@@ -2231,7 +3345,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e331_165750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e331_165750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 332,
@@ -2243,7 +3365,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e332_166250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e332_166250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 333,
@@ -2255,7 +3385,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e333_166750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e333_166750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 334,
@@ -2267,7 +3404,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e334_167250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e334_167250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 335,
@@ -2279,7 +3424,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e335_167750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e335_167750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 336,
@@ -2291,7 +3444,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e336_168250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e336_168250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 337,
@@ -2303,7 +3463,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e337_168750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e337_168750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 338,
@@ -2315,7 +3482,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e338_169250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e338_169250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 339,
@@ -2327,7 +3502,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e339_169750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e339_169750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 340,
@@ -2339,7 +3522,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e340_170250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e340_170250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 341,
@@ -2351,7 +3541,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 24,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e341_170750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e341_170750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 342,
@@ -2363,7 +3561,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 26,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e342_171250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e342_171250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 343,
@@ -2375,7 +3580,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e343_171750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e343_171750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 344,
@@ -2387,7 +3600,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 29,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e344_172250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e344_172250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 345,
@@ -2399,7 +3620,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e345_172750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e345_172750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 346,
@@ -2411,7 +3640,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e346_173250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e346_173250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 347,
@@ -2423,7 +3660,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 64,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e347_173750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e347_173750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 348,
@@ -2435,7 +3679,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 56,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e348_174250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e348_174250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 349,
@@ -2447,7 +3699,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 29,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e349_174750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e349_174750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 350,
@@ -2459,7 +3718,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 24,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e350_175250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e350_175250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 351,
@@ -2471,7 +3738,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e351_175750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e351_175750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 352,
@@ -2483,7 +3758,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e352_176250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e352_176250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 353,
@@ -2495,7 +3777,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e353_176750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e353_176750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 354,
@@ -2507,7 +3796,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e354_177250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e354_177250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 355,
@@ -2519,7 +3815,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e355_177750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e355_177750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 356,
@@ -2531,7 +3834,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e356_178250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e356_178250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 357,
@@ -2543,7 +3853,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e357_178750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e357_178750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 358,
@@ -2555,7 +3872,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e358_179250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e358_179250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 359,
@@ -2567,13 +3891,20 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e359_179749_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg.mp4_e359_179749_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     }
   ],
   "cycles": [
-    "Pink/Magenta↓ Unknown Green↑ Pink/Magenta Green Unknown↓ Yellow Yellow Unknown↓ Unknown↑ Unknown↓ Unknown↑ Unknown↑ Unknown Yellow↓ Yellow↓ Green↓ Yellow",
-    "Unknown↑ Unknown↑ Unknown Blue Yellow↓ Yellow↓ Unknown↓ Yellow Pink/Magenta↓ Pink/Magenta↓ Unknown↓ Unknown↑ Pink/Magenta Unknown Unknown↓ Pink/Magenta Yellow Unknown↑ Unknown↑ Unknown↑ Unknown↑ Pink/Magenta↑ Green Unknown↓ Yellow Yellow Yellow↑ Unknown Yellow Yellow Blue Yellow↓ Unknown Blue Yellow↑ Yellow Yellow↓ Yellow↓ Yellow Blue Unknown↑ Unknown↓ Yellow↓ Blue Yellow Yellow Yellow↑ Unknown↑ Unknown Yellow Blue Blue↓ Pink/Magenta↑ Unknown Blue Green Unknown Green Yellow Blue Unknown Yellow Blue Blue Unknown Blue Blue Blue Unknown↑ Blue Blue Blue Green↑ Green↑ Blue Blue Green↑ Yellow↓ Blue Yellow",
-    "Blue Unknown↓ Blue Blue Blue Blue Blue Blue Blue Blue Unknown Blue Unknown↑ Unknown↑ Unknown↓ Unknown Unknown↓ Yellow↓ Yellow Unknown↓ Unknown↓ Yellow Unknown↓ Unknown↓ Pink/Magenta↓ Yellow↓ Pink/Magenta↓ Unknown↓ Unknown↓ Pink/Magenta↓ Pink/Magenta↑ Pink/Magenta↓ Blue Unknown↑ Unknown↓ Blue Blue Blue Pink/Magenta Yellow↓ Yellow↓ Blue Blue Unknown↓ Blue Blue Unknown Unknown↑ Unknown↑ Blue↓ Blue↑ Pink/Magenta↓ Yellow↓ Pink/Magenta Unknown↓ Pink/Magenta↓ Unknown Unknown Blue↑ Yellow↑ Unknown Green↓ Pink/Magenta Blue↓ Pink/Magenta↓ Unknown↑ Yellow↓ Unknown Green↑ Pink/Magenta Green↓ Unknown↑ Blue Blue Blue Blue Blue Blue Blue Blue"
+    "Pink/Magenta↓ V0 Unknown V0 Green↑ V0 Pink/Magenta V0 Green V0 Unknown↓ V0 Yellow V0 Yellow V0 Unknown↓ V0 Unknown↑ V0 Unknown↓ V0 Unknown↑ V0 Unknown↑ V0 Unknown V0 Yellow↓ V0 Yellow↓ V0 Green↓ V0 Yellow V0",
+    "Unknown↑ V0 Unknown↑ V0 Unknown V0 Blue V0 Yellow↓ V0 Yellow↓ V0 Unknown↓ V0 Yellow V0 Pink/Magenta↓ V0 Pink/Magenta↓ V0 Unknown↓ V0 Unknown↑ V0 Pink/Magenta V0 Unknown V0 Unknown↓ V0 Pink/Magenta V0 Yellow V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Pink/Magenta↑ V0 Green V0 Unknown↓ V0 Yellow V0 Yellow V0 Yellow↑ V0 Unknown V0 Yellow V0 Yellow V0 Blue V0 Yellow↓ V0 Unknown V0 Blue V0 Yellow↑ V0 Yellow V0 Yellow↓ V0 Yellow↓ V0 Yellow V0 Blue V0 Unknown↑ V0 Unknown↓ V0 Yellow↓ V0 Blue V0 Yellow V0 Yellow V0 Yellow↑ V0 Unknown↑ V0 Unknown V0 Yellow V0 Blue V0 Blue↓ V0 Pink/Magenta↑ V0 Unknown V0 Blue V0 Green V0 Unknown V0 Green V0 Yellow V0 Blue V0 Unknown V0 Yellow V0 Blue V0 Blue V0 Unknown V0 Blue V0 Blue V0 Blue V0 Unknown↑ V0 Blue V0 Blue V0 Blue V0 Green↑ V0 Green↑ V0 Blue V0 Blue V0 Green↑ V0 Yellow↓ V0 Blue V0 Yellow V0",
+    "Blue V0 Unknown↓ V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Unknown V0 Blue V0 Unknown↑ V0 Unknown↑ V0 Unknown↓ V0 Unknown V0 Unknown↓ V0 Yellow↓ V0 Yellow V0 Unknown↓ V0 Unknown↓ V0 Yellow V0 Unknown↓ V0 Unknown↓ V0 Pink/Magenta↓ V0 Yellow↓ V0 Pink/Magenta↓ V0 Unknown↓ V0 Unknown↓ V0 Pink/Magenta↓ V0 Pink/Magenta↑ V0 Pink/Magenta↓ V0 Blue V0 Unknown↑ V0 Unknown↓ V0 Blue V0 Blue V0 Blue V0 Pink/Magenta V0 Yellow↓ V0 Yellow↓ V0 Blue V0 Blue V0 Unknown↓ V0 Blue V0 Blue V0 Unknown V0 Unknown↑ V0 Unknown↑ V0 Blue↓ V0 Blue↑ V0 Pink/Magenta↓ V0 Yellow↓ V0 Pink/Magenta V0 Unknown↓ V0 Pink/Magenta↓ V0 Unknown V0 Unknown V0 Blue↑ V0 Yellow↑ V0 Unknown V0 Green↓ V0 Pink/Magenta V0 Blue↓ V0 Pink/Magenta↓ V0 Unknown↑ V0 Yellow↓ V0 Unknown V0 Green↑ V0 Pink/Magenta V0 Green↓ V0 Unknown↑ V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0"
   ],
   "clustering": {
     "eps": 0.34,

--- a/public/sequences_merge/v12044gd0000d2husv7og65snaorfbcg3.mp4.json.sequence.json
+++ b/public/sequences_merge/v12044gd0000d2husv7og65snaorfbcg3.mp4.json.sequence.json
@@ -395,7 +395,7 @@
     }
   },
   "symbol_seq": "JAAUABBFBCBCCAAYWBJVPPEAWRKUHANQIEAABACABBUBAJBCABIIAGDDDBBGBUOOABBACBHALGEQQKKHULANANHHHAAAEAKAETAWKAJAGFAAAFBADLBAZVLAOPACE",
-  "symbol_seq_enhanced": "Blue Blue Blue Yellow↑ Blue Blue Blue Blue↑ Green↑ Green↑ Blue Blue Green↑ Yellow↓ Blue Blue↓ Pink/Magenta↑ Yellow↑ Yellow↓ Unknown↓ Unknown↓ Yellow↓ Unknown↓ Yellow↓ Yellow↑ Unknown↓ Unknown Yellow Unknown↓ Blue Blue Blue Blue Blue Blue Blue Blue Yellow↑ Blue Green↑ Blue Blue Blue Blue Yellow↓ Yellow↓ Blue Blue Blue Blue Blue Blue Blue Blue↓ Blue Yellow↓ Blue Blue Blue Blue Blue Blue Blue Blue Yellow↓ Blue Unknown Blue↑ Unknown↓ Unknown↓ Unknown↓ Unknown↓ Unknown↓ Yellow↓ Yellow Unknown↓ Unknown↑ Unknown↑ Yellow↓ Yellow↓ Yellow Pink/Magenta↓ Blue↑ Pink/Magenta↓ Blue↓ Pink/Magenta↓ Unknown↓ Unknown↓ Blue Blue Blue Blue Blue Blue Blue Pink/Magenta↓ Blue Blue Blue Unknown↓ Blue Unknown↑ Pink/Magenta↓ Unknown Green↑ Yellow↑ Pink/Magenta↓ Unknown↑",
+  "symbol_seq_enhanced": "Blue V0 Blue V0 Blue V0 Yellow↑ V0 Blue V0 Blue V0 Blue V0 Blue↑ V0 Green↑ V0 Green↑ V0 Blue V0 Blue V0 Green↑ V0 Yellow↓ V0 Blue V0 Blue↓ V0 Pink/Magenta↑ V0 Yellow↑ V0 Yellow↓ V0 Unknown↓ V0 Unknown↓ V0 Yellow↓ V0 Unknown↓ V0 Yellow↓ V0 Yellow↑ V0 Unknown↓ V0 Unknown V0 Yellow V0 Unknown↓ V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Yellow↑ V0 Blue V0 Green↑ V0 Blue V0 Blue V0 Blue V0 Blue V0 Yellow↓ V0 Yellow↓ V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue↓ V0 Blue V0 Yellow↓ V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Yellow↓ V0 Blue V0 Unknown V0 Blue↑ V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Yellow↓ V0 Yellow V0 Unknown↓ V0 Unknown↑ V0 Unknown↑ V0 Yellow↓ V0 Yellow↓ V0 Yellow V0 Pink/Magenta↓ V0 Blue↑ V0 Pink/Magenta↓ V0 Blue↓ V0 Pink/Magenta↓ V0 Unknown↓ V0 Unknown↓ V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Pink/Magenta↓ V0 Blue V0 Blue V0 Blue V0 Unknown↓ V0 Blue V0 Unknown↑ V0 Pink/Magenta↓ V0 Unknown V0 Green↑ V0 Yellow↑ V0 Pink/Magenta↓ V0 Unknown↑ V0",
   "binary_seq": "011011001110001000000000000001111110101011110010111010100011111101000000000011000000001010101000111010000000",
   "v_threshold": 0.594,
   "events": [
@@ -409,7 +409,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e000_000250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e000_000250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 1,
@@ -421,7 +428,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e001_000750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e001_000750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 2,
@@ -433,7 +447,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e002_001250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e002_001250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 3,
@@ -445,7 +466,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e003_001750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e003_001750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 4,
@@ -457,7 +486,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e004_002250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e004_002250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 5,
@@ -469,7 +505,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e005_002750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e005_002750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 6,
@@ -481,7 +524,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e006_003250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e006_003250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 7,
@@ -493,7 +543,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e007_003750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e007_003750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 8,
@@ -505,7 +563,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 69,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e008_004250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e008_004250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 9,
@@ -517,7 +583,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 69,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e009_004750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e009_004750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 10,
@@ -529,7 +603,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e010_005250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e010_005250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 11,
@@ -541,7 +622,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e011_005750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e011_005750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 12,
@@ -553,7 +641,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 45,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e012_006250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e012_006250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 13,
@@ -565,7 +661,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e013_006750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e013_006750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 14,
@@ -577,7 +681,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e014_007250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e014_007250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 15,
@@ -589,7 +700,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e015_007750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e015_007750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 16,
@@ -601,7 +720,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e016_008250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e016_008250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 17,
@@ -613,7 +740,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e017_008750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e017_008750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 18,
@@ -625,7 +760,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e018_009250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e018_009250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 19,
@@ -637,7 +780,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e019_009750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e019_009750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 20,
@@ -649,7 +800,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 58,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e020_010250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e020_010250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 21,
@@ -661,7 +820,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e021_010750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e021_010750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 22,
@@ -673,7 +840,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e022_011250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e022_011250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 23,
@@ -685,7 +860,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e023_011750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e023_011750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 24,
@@ -697,7 +880,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e024_012250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e024_012250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 25,
@@ -709,7 +900,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 27,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e025_012750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e025_012750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 26,
@@ -721,7 +920,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e026_013250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e026_013250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 27,
@@ -733,7 +939,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e027_013750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e027_013750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 28,
@@ -745,7 +958,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e028_014250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e028_014250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 29,
@@ -757,7 +978,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e029_014750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e029_014750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 30,
@@ -769,7 +997,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e030_015250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e030_015250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 31,
@@ -781,7 +1016,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e031_015750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e031_015750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 32,
@@ -793,7 +1035,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e032_016250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e032_016250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 33,
@@ -805,7 +1054,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e033_016750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e033_016750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 34,
@@ -817,7 +1073,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e034_017250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e034_017250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 35,
@@ -829,7 +1092,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e035_017750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e035_017750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 36,
@@ -841,7 +1111,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e036_018250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e036_018250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 37,
@@ -853,7 +1130,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e037_018750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e037_018750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 38,
@@ -865,7 +1150,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e038_019250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e038_019250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 39,
@@ -877,7 +1169,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 24,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e039_019749_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e039_019749_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 40,
@@ -889,7 +1189,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e040_020250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e040_020250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 41,
@@ -901,7 +1208,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e041_020750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e041_020750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 42,
@@ -913,7 +1227,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e042_021250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e042_021250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 43,
@@ -925,7 +1246,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e043_021750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e043_021750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 44,
@@ -937,7 +1265,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e044_022250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e044_022250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 45,
@@ -949,7 +1285,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e045_022750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e045_022750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 46,
@@ -961,7 +1305,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e046_023250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e046_023250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 47,
@@ -973,7 +1324,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e047_023750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e047_023750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 48,
@@ -985,7 +1343,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e048_024250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e048_024250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 49,
@@ -997,7 +1362,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e049_024750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e049_024750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 50,
@@ -1009,7 +1381,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e050_025250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e050_025250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 51,
@@ -1021,7 +1400,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e051_025750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e051_025750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 52,
@@ -1033,7 +1419,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e052_026250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e052_026250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 53,
@@ -1045,7 +1438,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e053_026750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e053_026750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 54,
@@ -1057,7 +1458,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e054_027250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e054_027250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 55,
@@ -1069,7 +1477,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e055_027750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e055_027750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 56,
@@ -1081,7 +1497,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e056_028250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e056_028250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 57,
@@ -1093,7 +1516,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e057_028750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e057_028750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 58,
@@ -1105,7 +1535,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e058_029250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e058_029250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 59,
@@ -1117,7 +1554,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e059_029750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e059_029750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 60,
@@ -1129,7 +1573,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e060_030250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e060_030250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 61,
@@ -1141,7 +1592,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e061_030750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e061_030750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 62,
@@ -1153,7 +1611,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e062_031250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e062_031250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 63,
@@ -1165,7 +1630,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e063_031750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e063_031750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 64,
@@ -1177,7 +1649,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e064_032250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e064_032250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 65,
@@ -1189,7 +1669,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e065_032750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e065_032750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 66,
@@ -1201,7 +1688,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e066_033250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e066_033250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 67,
@@ -1213,7 +1707,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e067_033750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e067_033750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 68,
@@ -1225,7 +1727,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e068_034250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e068_034250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 69,
@@ -1237,7 +1747,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e069_034750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e069_034750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 70,
@@ -1249,7 +1767,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e070_035250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e070_035250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 71,
@@ -1261,7 +1787,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e071_035750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e071_035750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 72,
@@ -1273,7 +1807,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e072_036250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e072_036250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 73,
@@ -1285,7 +1827,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e073_036750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e073_036750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 74,
@@ -1297,7 +1847,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e074_037250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e074_037250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 75,
@@ -1309,7 +1866,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e075_037750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e075_037750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 76,
@@ -1321,7 +1886,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 27,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e076_038250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e076_038250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 77,
@@ -1333,7 +1906,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 27,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e077_038750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e077_038750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 78,
@@ -1345,7 +1926,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e078_039250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e078_039250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 79,
@@ -1357,7 +1946,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e079_039749_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e079_039749_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 80,
@@ -1369,7 +1966,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e080_040250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e080_040250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 81,
@@ -1381,7 +1985,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 70,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e081_040750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e081_040750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 82,
@@ -1393,7 +2005,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 34,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e082_041250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e082_041250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 83,
@@ -1405,7 +2025,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 29,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e083_041750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e083_041750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 84,
@@ -1417,7 +2045,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 34,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e084_042250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e084_042250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 85,
@@ -1429,7 +2065,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e085_042750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e085_042750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 86,
@@ -1441,7 +2085,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 58,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e086_043250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e086_043250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 87,
@@ -1453,7 +2105,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e087_043750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e087_043750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 88,
@@ -1465,7 +2125,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e088_044250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e088_044250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 89,
@@ -1477,7 +2144,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e089_044750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e089_044750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 90,
@@ -1489,7 +2163,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e090_045250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e090_045250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 91,
@@ -1501,7 +2182,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e091_045750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e091_045750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 92,
@@ -1513,7 +2201,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e092_046250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e092_046250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 93,
@@ -1525,7 +2220,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e093_046750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e093_046750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 94,
@@ -1537,7 +2239,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e094_047250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e094_047250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 95,
@@ -1549,7 +2258,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 54,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e095_047750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e095_047750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 96,
@@ -1561,7 +2278,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e096_048250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e096_048250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 97,
@@ -1573,7 +2297,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e097_048750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e097_048750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 98,
@@ -1585,7 +2316,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e098_049250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e098_049250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 99,
@@ -1597,7 +2335,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e099_049750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e099_049750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 100,
@@ -1609,7 +2355,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e100_050250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e100_050250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 101,
@@ -1621,7 +2374,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 68,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e101_050750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e101_050750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 102,
@@ -1633,7 +2394,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e102_051250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e102_051250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 103,
@@ -1645,7 +2414,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e103_051750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e103_051750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 104,
@@ -1657,7 +2433,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 41,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e104_052250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e104_052250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 105,
@@ -1669,7 +2453,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e105_052750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e105_052750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 106,
@@ -1681,7 +2473,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 38,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e106_053250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e106_053250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 107,
@@ -1693,11 +2493,19 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e107_053750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg3.mp4_e107_053750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     }
   ],
   "cycles": [
-    "Blue Blue Blue Yellow↑ Blue Blue Blue Blue↑ Green↑ Green↑ Blue Blue Green↑ Yellow↓ Blue Blue↓ Pink/Magenta↑ Yellow↑ Yellow↓ Unknown↓ Unknown↓ Yellow↓ Unknown↓ Yellow↓ Yellow↑ Unknown↓ Unknown Yellow Unknown↓ Blue Blue Blue Blue Blue Blue Blue Blue Yellow↑ Blue Green↑ Blue Blue Blue Blue Yellow↓ Yellow↓ Blue Blue Blue Blue Blue Blue Blue Blue↓ Blue Yellow↓ Blue Blue Blue Blue Blue Blue Blue Blue Yellow↓ Blue Unknown Blue↑ Unknown↓ Unknown↓ Unknown↓ Unknown↓ Unknown↓ Yellow↓ Yellow Unknown↓ Unknown↑ Unknown↑ Yellow↓ Yellow↓ Yellow Pink/Magenta↓ Blue↑ Pink/Magenta↓ Blue↓ Pink/Magenta↓ Unknown↓ Unknown↓ Blue Blue Blue Blue Blue Blue Blue Pink/Magenta↓ Blue Blue Blue Unknown↓ Blue Unknown↑ Pink/Magenta↓ Unknown Green↑ Yellow↑ Pink/Magenta↓ Unknown↑"
+    "Blue V0 Blue V0 Blue V0 Yellow↑ V0 Blue V0 Blue V0 Blue V0 Blue↑ V0 Green↑ V0 Green↑ V0 Blue V0 Blue V0 Green↑ V0 Yellow↓ V0 Blue V0 Blue↓ V0 Pink/Magenta↑ V0 Yellow↑ V0 Yellow↓ V0 Unknown↓ V0 Unknown↓ V0 Yellow↓ V0 Unknown↓ V0 Yellow↓ V0 Yellow↑ V0 Unknown↓ V0 Unknown V0 Yellow V0 Unknown↓ V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Yellow↑ V0 Blue V0 Green↑ V0 Blue V0 Blue V0 Blue V0 Blue V0 Yellow↓ V0 Yellow↓ V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue↓ V0 Blue V0 Yellow↓ V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Yellow↓ V0 Blue V0 Unknown V0 Blue↑ V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Yellow↓ V0 Yellow V0 Unknown↓ V0 Unknown↑ V0 Unknown↑ V0 Yellow↓ V0 Yellow↓ V0 Yellow V0 Pink/Magenta↓ V0 Blue↑ V0 Pink/Magenta↓ V0 Blue↓ V0 Pink/Magenta↓ V0 Unknown↓ V0 Unknown↓ V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Pink/Magenta↓ V0 Blue V0 Blue V0 Blue V0 Unknown↓ V0 Blue V0 Unknown↑ V0 Pink/Magenta↓ V0 Unknown V0 Green↑ V0 Yellow↑ V0 Pink/Magenta↓ V0 Unknown↑ V0"
   ],
   "clustering": {
     "eps": 0.34,

--- a/public/sequences_merge/v12044gd0000d2husv7og65snaorfbcg4.mp4.json.sequence.json
+++ b/public/sequences_merge/v12044gd0000d2husv7og65snaorfbcg4.mp4.json.sequence.json
@@ -276,7 +276,7 @@
     }
   },
   "symbol_seq": "ADBBBBCBCAAABAAHBCDGBA___ATY_AAASAFAFAOAG_AEAEARAFXXXASYN_JASTCCAHAFAFGGAB",
-  "symbol_seq_enhanced": "Blue Blue Blue Blue Blue Green↓ Green↓ Blue Blue Blue Blue Blue Pink/Magenta Blue Blue Blue Blue Blue Blue Pink/Magenta↑ Pink/Magenta↓ Unknown Unknown↑ Unknown↑ Unknown↓ Pink/Magenta↑ Unknown↑ Pink/Magenta Pink/Magenta Green↑ Pink/Magenta↑ Pink/Magenta Blue Blue Unknown Pink/Magenta Unknown Unknown Unknown Unknown Unknown Blue↑ Pink/Magenta Blue Unknown↑ Pink/Magenta↑ Blue Blue Pink/Magenta↑ Pink/Magenta↑ Pink/Magenta↑ Blue↑ Blue↑ Pink/Magenta↓",
+  "symbol_seq_enhanced": "Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Green↓ V0 Green↓ V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Pink/Magenta V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Pink/Magenta↑ V0 Pink/Magenta↓ V0 Unknown V0 Unknown↑ V0 Unknown↑ V0 Unknown↓ V0 Pink/Magenta↑ V0 Unknown↑ V0 Pink/Magenta V0 Pink/Magenta V0 Green↑ V0 Pink/Magenta↑ V0 Pink/Magenta V0 Blue V0 Blue V0 Unknown V0 Pink/Magenta V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Blue↑ V0 Pink/Magenta V0 Blue V0 Unknown↑ V0 Pink/Magenta↑ V0 Blue V0 Blue V0 Pink/Magenta↑ V0 Pink/Magenta↑ V0 Pink/Magenta↑ V0 Blue↑ V0 Blue↑ V0 Pink/Magenta↓ V0",
   "binary_seq": "111111110111010101101010000000000000001000000000100000",
   "v_threshold": 0.522,
   "events": [
@@ -290,7 +290,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e000_000250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e000_000250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 1,
@@ -302,7 +309,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e001_000750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e001_000750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 2,
@@ -314,7 +328,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e002_001250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e002_001250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 3,
@@ -326,7 +347,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e003_001750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e003_001750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 4,
@@ -338,7 +366,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e004_002250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e004_002250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 5,
@@ -350,7 +385,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 69,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e005_002750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e005_002750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 6,
@@ -362,7 +405,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 69,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e006_003250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e006_003250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 7,
@@ -374,7 +425,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e007_003750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e007_003750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 8,
@@ -386,7 +444,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e008_004250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e008_004250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 9,
@@ -398,7 +463,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e009_004750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e009_004750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 10,
@@ -410,7 +482,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e010_005250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e010_005250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 11,
@@ -422,7 +501,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e011_005750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e011_005750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 12,
@@ -434,7 +520,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 31,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e012_006250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e012_006250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 13,
@@ -446,7 +539,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e013_006750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e013_006750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 14,
@@ -458,7 +558,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e014_007250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e014_007250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 15,
@@ -470,7 +577,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e015_007750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e015_007750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 16,
@@ -482,7 +596,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e016_008250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e016_008250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 17,
@@ -494,7 +615,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e017_008750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e017_008750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 18,
@@ -506,7 +634,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e018_009250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e018_009250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 19,
@@ -518,7 +653,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": -6,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e019_009750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e019_009750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 20,
@@ -530,7 +673,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": -6,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e020_010250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e020_010250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 21,
@@ -542,7 +693,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": -2,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e021_010750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e021_010750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 22,
@@ -554,7 +712,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 32,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e022_011250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e022_011250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 23,
@@ -566,7 +732,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e023_011750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e023_011750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 24,
@@ -578,7 +752,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": -2,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e024_012250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e024_012250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 25,
@@ -590,7 +772,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 70,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e025_012750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e025_012750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 26,
@@ -602,7 +792,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 64,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e026_013250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e026_013250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 27,
@@ -614,7 +812,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 54,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e027_013750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e027_013750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 28,
@@ -626,7 +831,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 54,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e028_014250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e028_014250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 29,
@@ -638,7 +850,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 41,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e029_014750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e029_014750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 30,
@@ -650,7 +870,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 26,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e030_015250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e030_015250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 31,
@@ -662,7 +890,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": -6,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e031_015750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e031_015750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 32,
@@ -674,7 +909,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 34,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e032_016250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e032_016250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 33,
@@ -686,7 +928,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 34,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e033_016750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e033_016750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 34,
@@ -698,7 +947,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 42,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e034_017250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e034_017250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 35,
@@ -710,7 +966,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 54,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e035_017750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e035_017750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 36,
@@ -722,7 +985,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 2,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e036_018250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e036_018250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 37,
@@ -734,7 +1004,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 2,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e037_018750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e037_018750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 38,
@@ -746,7 +1023,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 2,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e038_019250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e038_019250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 39,
@@ -758,7 +1042,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 64,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e039_019733_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e039_019733_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 40,
@@ -770,7 +1061,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e040_020250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e040_020250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 41,
@@ -782,7 +1080,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e041_020750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e041_020750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 42,
@@ -794,7 +1100,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": -6,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e042_021250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e042_021250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 43,
@@ -806,7 +1119,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e043_021750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e043_021750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 44,
@@ -818,7 +1138,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 64,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e044_022250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e044_022250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 45,
@@ -830,7 +1158,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e045_022750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e045_022750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 46,
@@ -842,7 +1178,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e046_023250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e046_023250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 47,
@@ -854,7 +1197,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e047_023750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e047_023750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 48,
@@ -866,7 +1216,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 31,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e048_024250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e048_024250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 49,
@@ -878,7 +1236,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 54,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e049_024750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e049_024750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 50,
@@ -890,7 +1256,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 54,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e050_025250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e050_025250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 51,
@@ -902,7 +1276,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e051_025750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e051_025750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 52,
@@ -914,7 +1296,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e052_026250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e052_026250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 53,
@@ -926,11 +1316,19 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 44,
-      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e053_026740_obj.jpg"
+      "thumb_obj": "v12044gd0000d2husv7og65snaorfbcg4.mp4_e053_026740_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     }
   ],
   "cycles": [
-    "Blue Blue Blue Blue Blue Green↓ Green↓ Blue Blue Blue Blue Blue Pink/Magenta Blue Blue Blue Blue Blue Blue Pink/Magenta↑ Pink/Magenta↓ Unknown Unknown↑ Unknown↑ Unknown↓ Pink/Magenta↑ Unknown↑ Pink/Magenta Pink/Magenta Green↑ Pink/Magenta↑ Pink/Magenta Blue Blue Unknown Pink/Magenta Unknown Unknown Unknown Unknown Unknown Blue↑ Pink/Magenta Blue Unknown↑ Pink/Magenta↑ Blue Blue Pink/Magenta↑ Pink/Magenta↑ Pink/Magenta↑ Blue↑ Blue↑ Pink/Magenta↓"
+    "Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Green↓ V0 Green↓ V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Pink/Magenta V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Pink/Magenta↑ V0 Pink/Magenta↓ V0 Unknown V0 Unknown↑ V0 Unknown↑ V0 Unknown↓ V0 Pink/Magenta↑ V0 Unknown↑ V0 Pink/Magenta V0 Pink/Magenta V0 Green↑ V0 Pink/Magenta↑ V0 Pink/Magenta V0 Blue V0 Blue V0 Unknown V0 Pink/Magenta V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Blue↑ V0 Pink/Magenta V0 Blue V0 Unknown↑ V0 Pink/Magenta↑ V0 Blue V0 Blue V0 Pink/Magenta↑ V0 Pink/Magenta↑ V0 Pink/Magenta↑ V0 Blue↑ V0 Blue↑ V0 Pink/Magenta↓ V0"
   ],
   "clustering": {
     "eps": 0.34,

--- a/public/sequences_merge/v12044gd0000d2i0647og65vlmef6qv0.json.sequence.json
+++ b/public/sequences_merge/v12044gd0000d2i0647og65vlmef6qv0.json.sequence.json
@@ -208,7 +208,7 @@
     }
   },
   "symbol_seq": "DDDDDDDDDDDDAPAPAPAPAPYYYYYYYYMMMMMMMAMAMAMAMAMUUUUUUAPAPAPAPAPAPAPBEBEBEBEBEOOOOOOTTTTTTTANANANANANAWAWAWAW",
-  "symbol_seq_enhanced": "Blue↓ Blue↓ Blue↓ Blue↓ Blue↓ Blue↓ Blue↓ Blue↓ Blue↓ Blue↓ Blue↓ Blue↓ Unknown↑ Unknown↑ Unknown↑ Unknown↑ Unknown↑ Unknown Unknown Unknown Unknown Unknown Unknown Unknown Unknown Blue↑ Blue↑ Blue↑ Blue↑ Blue↑ Blue↑ Blue↑ Unknown↓ Unknown↓ Unknown↓ Unknown↓ Unknown↓ Yellow Yellow Yellow Yellow Yellow Yellow Unknown↑ Unknown↑ Unknown↑ Unknown↑ Unknown↑ Unknown↑ Unknown↑ Green Green Green Green Green Blue Blue Blue Blue Blue Blue Pink/Magenta↑ Pink/Magenta↑ Pink/Magenta↑ Pink/Magenta↑ Pink/Magenta↑ Pink/Magenta↑ Pink/Magenta↑ Unknown Unknown Unknown Unknown Unknown Unknown Unknown Unknown Unknown",
+  "symbol_seq_enhanced": "Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Yellow V0 Yellow V0 Yellow V0 Yellow V0 Yellow V0 Yellow V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Green V0 Green V0 Green V0 Green V0 Green V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Pink/Magenta↑ V0 Pink/Magenta↑ V0 Pink/Magenta↑ V0 Pink/Magenta↑ V0 Pink/Magenta↑ V0 Pink/Magenta↑ V0 Pink/Magenta↑ V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0",
   "binary_seq": "11111111111100000000000001111111111110000000000000000000000000000000000000000",
   "v_threshold": 0.396,
   "events": [
@@ -222,7 +222,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e000_000250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e000_000250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 1,
@@ -234,7 +242,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e001_000750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e001_000750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 2,
@@ -246,7 +262,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e002_001250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e002_001250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 3,
@@ -258,7 +282,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e003_001750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e003_001750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 4,
@@ -270,7 +302,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e004_002250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e004_002250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 5,
@@ -282,7 +322,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e005_002750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e005_002750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 6,
@@ -294,7 +342,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e006_003250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e006_003250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 7,
@@ -306,7 +362,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e007_003750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e007_003750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 8,
@@ -318,7 +382,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e008_004250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e008_004250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 9,
@@ -330,7 +402,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e009_004750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e009_004750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 10,
@@ -342,7 +422,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e010_005250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e010_005250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 11,
@@ -354,7 +442,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e011_005750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e011_005750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 12,
@@ -366,7 +462,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 9,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e012_006250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e012_006250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 13,
@@ -378,7 +482,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 9,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e013_006750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e013_006750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 14,
@@ -390,7 +502,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 9,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e014_007250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e014_007250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 15,
@@ -402,7 +522,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 9,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e015_007750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e015_007750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 16,
@@ -414,7 +542,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 9,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e016_008250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e016_008250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 17,
@@ -426,7 +562,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e017_008750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e017_008750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 18,
@@ -438,7 +581,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e018_009250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e018_009250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 19,
@@ -450,7 +600,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e019_009750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e019_009750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 20,
@@ -462,7 +619,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e020_010250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e020_010250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 21,
@@ -474,7 +638,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e021_010750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e021_010750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 22,
@@ -486,7 +657,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e022_011250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e022_011250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 23,
@@ -498,7 +676,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e023_011750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e023_011750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 24,
@@ -510,7 +695,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e024_012250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e024_012250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 25,
@@ -522,7 +714,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e025_012750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e025_012750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 26,
@@ -534,7 +734,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e026_013250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e026_013250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 27,
@@ -546,7 +754,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e027_013750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e027_013750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 28,
@@ -558,7 +774,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e028_014250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e028_014250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 29,
@@ -570,7 +794,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e029_014750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e029_014750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 30,
@@ -582,7 +814,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e030_015250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e030_015250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 31,
@@ -594,7 +834,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e031_015750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e031_015750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 32,
@@ -606,7 +854,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 7,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e032_016250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e032_016250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 33,
@@ -618,7 +874,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 7,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e033_016750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e033_016750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 34,
@@ -630,7 +894,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 7,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e034_017250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e034_017250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 35,
@@ -642,7 +914,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 7,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e035_017750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e035_017750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 36,
@@ -654,7 +934,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 7,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e036_018250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e036_018250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 37,
@@ -666,7 +954,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e037_018750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e037_018750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 38,
@@ -678,7 +973,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e038_019250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e038_019250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 39,
@@ -690,7 +992,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e039_019750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e039_019750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 40,
@@ -702,7 +1011,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e040_020250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e040_020250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 41,
@@ -714,7 +1030,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e041_020750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e041_020750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 42,
@@ -726,7 +1049,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e042_021250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e042_021250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 43,
@@ -738,7 +1068,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 9,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e043_021750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e043_021750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 44,
@@ -750,7 +1088,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 9,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e044_022250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e044_022250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 45,
@@ -762,7 +1108,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 9,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e045_022750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e045_022750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 46,
@@ -774,7 +1128,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 9,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e046_023250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e046_023250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 47,
@@ -786,7 +1148,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 9,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e047_023750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e047_023750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 48,
@@ -798,7 +1168,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 9,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e048_024250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e048_024250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 49,
@@ -810,7 +1188,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 9,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e049_024750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e049_024750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 50,
@@ -822,7 +1208,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 57,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e050_025250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e050_025250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 51,
@@ -834,7 +1227,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 57,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e051_025750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e051_025750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 52,
@@ -846,7 +1246,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 57,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e052_026250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e052_026250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 53,
@@ -858,7 +1265,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 57,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e053_026750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e053_026750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 54,
@@ -870,7 +1284,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 57,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e054_027250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e054_027250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 55,
@@ -882,7 +1303,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e055_027750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e055_027750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 56,
@@ -894,7 +1322,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e056_028250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e056_028250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 57,
@@ -906,7 +1341,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e057_028750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e057_028750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 58,
@@ -918,7 +1360,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e058_029250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e058_029250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 59,
@@ -930,7 +1379,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e059_029750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e059_029750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 60,
@@ -942,7 +1398,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e060_030250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e060_030250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 61,
@@ -954,7 +1417,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e061_030750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e061_030750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 62,
@@ -966,7 +1437,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e062_031250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e062_031250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 63,
@@ -978,7 +1457,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e063_031750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e063_031750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 64,
@@ -990,7 +1477,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e064_032250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e064_032250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 65,
@@ -1002,7 +1497,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e065_032750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e065_032750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 66,
@@ -1014,7 +1517,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e066_033250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e066_033250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 67,
@@ -1026,7 +1537,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e067_033750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e067_033750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 68,
@@ -1038,7 +1557,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 27,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e068_034250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e068_034250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 69,
@@ -1050,7 +1576,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 27,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e069_034750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e069_034750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 70,
@@ -1062,7 +1595,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 27,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e070_035250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e070_035250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 71,
@@ -1074,7 +1614,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 27,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e071_035750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e071_035750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 72,
@@ -1086,7 +1633,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 27,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e072_036250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e072_036250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 73,
@@ -1098,7 +1652,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 58,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e073_036750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e073_036750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 74,
@@ -1110,7 +1671,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 58,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e074_037250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e074_037250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 75,
@@ -1122,7 +1690,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 58,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e075_037750_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e075_037750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 76,
@@ -1134,11 +1709,18 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 58,
-      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e076_038250_obj.jpg"
+      "thumb_obj": "v12044gd0000d2i0647og65vlmef6qv0_e076_038250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     }
   ],
   "cycles": [
-    "Blue↓ Blue↓ Blue↓ Blue↓ Blue↓ Blue↓ Blue↓ Blue↓ Blue↓ Blue↓ Blue↓ Blue↓ Unknown↑ Unknown↑ Unknown↑ Unknown↑ Unknown↑ Unknown Unknown Unknown Unknown Unknown Unknown Unknown Unknown Blue↑ Blue↑ Blue↑ Blue↑ Blue↑ Blue↑ Blue↑ Unknown↓ Unknown↓ Unknown↓ Unknown↓ Unknown↓ Yellow Yellow Yellow Yellow Yellow Yellow Unknown↑ Unknown↑ Unknown↑ Unknown↑ Unknown↑ Unknown↑ Unknown↑ Green Green Green Green Green Blue Blue Blue Blue Blue Blue Pink/Magenta↑ Pink/Magenta↑ Pink/Magenta↑ Pink/Magenta↑ Pink/Magenta↑ Pink/Magenta↑ Pink/Magenta↑ Unknown Unknown Unknown Unknown Unknown Unknown Unknown Unknown Unknown"
+    "Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Yellow V0 Yellow V0 Yellow V0 Yellow V0 Yellow V0 Yellow V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Green V0 Green V0 Green V0 Green V0 Green V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Pink/Magenta↑ V0 Pink/Magenta↑ V0 Pink/Magenta↑ V0 Pink/Magenta↑ V0 Pink/Magenta↑ V0 Pink/Magenta↑ V0 Pink/Magenta↑ V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0"
   ],
   "clustering": {
     "eps": 0.34,

--- a/public/sequences_merge/v15044gf0000d29l69nog65hkej1drug.json.sequence.json
+++ b/public/sequences_merge/v15044gf0000d29l69nog65hkej1drug.json.sequence.json
@@ -412,7 +412,7 @@
     }
   },
   "symbol_seq": "ASMAJXXOXAQNFAMFAYAYYYAJAJNNNXYYXNNNAYFFFIOOXOOYNNNAEOOOUUAYAWYYARARAJAJAUAKXXAVXOATALMONFFGAFFJAZOOFFFAAAQAQAJUAZAZYAQDOWDDNNALXFFYYRAFNNAUAYKATATAONTAJPH",
-  "symbol_seq_enhanced": "Unknown Blue↑ Green↑ Unknown Unknown Blue Unknown Green↓ Blue↓ Blue Unknown Blue Green↑ Green↑ Unknown Unknown Green↑ Green↑ Blue Blue Blue Unknown Unknown↑ Unknown↑ Unknown↓ Blue Blue Blue Green Blue Blue Blue Yellow Blue↑ Blue↑ Unknown Blue Blue Unknown Blue Blue Blue Blue Blue Blue Blue↑ Yellow Yellow Green↓ Unknown↓ Unknown Unknown Unknown↑ Unknown↑ Green↑ Green Green↓ Pink/Magenta Unknown Unknown Unknown Unknown Blue Unknown Green Blue↑ Blue Blue Blue Blue Blue Blue Blue Blue Blue Unknown Blue Blue Blue Blue Blue Blue Blue Green Green↓ Green Yellow Unknown Unknown Unknown↓ Green↑ Blue Blue Yellow↓ Blue Blue Blue Blue Green↓ Blue↑ Blue↑ Blue↑ Unknown↓ Unknown↓ Yellow Pink/Magenta↓ Blue Blue Green Green↓ Unknown↑ Unknown Unknown Green Blue↑ Pink/Magenta↑ Green↑ Yellow↑ Unknown↑",
+  "symbol_seq_enhanced": "Unknown V0 Blue↑ V0 Green↑ V0 Unknown V0 Unknown V0 Blue V0 Unknown V0 Green↓ V0 Blue↓ V0 Blue V0 Unknown V0 Blue V0 Green↑ V0 Green↑ V0 Unknown V0 Unknown V0 Green↑ V0 Green↑ V0 Blue V0 Blue V0 Blue V0 Unknown V0 Unknown↑ V0 Unknown↑ V0 Unknown↓ V0 Blue V0 Blue V0 Blue V0 Green V0 Blue V0 Blue V0 Blue V0 Yellow V0 Blue↑ V0 Blue↑ V0 Unknown V0 Blue V0 Blue V0 Unknown V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue↑ V0 Yellow V0 Yellow V0 Green↓ V0 Unknown↓ V0 Unknown V0 Unknown V0 Unknown↑ V0 Unknown↑ V0 Green↑ V0 Green V0 Green↓ V0 Pink/Magenta V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Blue V0 Unknown V0 Green V0 Blue↑ V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Unknown V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Green V0 Green↓ V0 Green V0 Yellow V0 Unknown V0 Unknown V0 Unknown↓ V0 Green↑ V0 Blue V0 Blue V0 Yellow↓ V0 Blue V0 Blue V0 Blue V0 Blue V0 Green↓ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Unknown↓ V0 Unknown↓ V0 Yellow V0 Pink/Magenta↓ V0 Blue V0 Blue V0 Green V0 Green↓ V0 Unknown↑ V0 Unknown V0 Unknown V0 Green V0 Blue↑ V0 Pink/Magenta↑ V0 Green↑ V0 Yellow↑ V0 Unknown↑ V0",
   "binary_seq": "00000100110100110011111001000000001011111001100000000000000001100000000111000000000000000001101111000000000000011010000",
   "v_threshold": 0.61,
   "events": [
@@ -426,7 +426,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 64,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e000_000250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e000_000250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 1,
@@ -438,7 +445,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e001_000750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e001_000750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 2,
@@ -450,7 +465,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 24,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e002_001250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e002_001250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 3,
@@ -462,7 +485,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 2,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e003_001750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e003_001750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 4,
@@ -474,7 +504,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 2,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e004_002250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e004_002250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 5,
@@ -486,7 +523,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e005_002750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e005_002750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 6,
@@ -498,7 +542,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 2,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e006_003250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e006_003250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 7,
@@ -510,7 +561,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 65,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e007_003750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e007_003750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 8,
@@ -522,7 +581,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e008_004250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e008_004250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 9,
@@ -534,7 +601,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e009_004750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e009_004750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 10,
@@ -546,7 +620,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 7,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e010_005250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e010_005250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 11,
@@ -558,7 +639,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e011_005750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e011_005750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 12,
@@ -570,7 +658,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 45,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e012_006250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e012_006250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 13,
@@ -582,7 +678,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 45,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e013_006750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e013_006750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 14,
@@ -594,7 +698,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e014_007250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e014_007250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 15,
@@ -606,7 +717,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e015_007750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e015_007750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 16,
@@ -618,7 +736,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 24,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e016_008250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e016_008250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 17,
@@ -630,7 +756,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 24,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e017_008750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e017_008750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 18,
@@ -642,7 +776,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e018_009250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e018_009250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 19,
@@ -654,7 +795,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e019_009750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e019_009750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 20,
@@ -666,7 +814,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e020_010250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e020_010250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 21,
@@ -678,7 +833,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 2,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e021_010750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e021_010750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 22,
@@ -690,7 +852,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e022_011250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e022_011250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 23,
@@ -702,7 +872,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e023_011750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e023_011750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 24,
@@ -714,7 +892,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 2,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e024_012250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e024_012250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 25,
@@ -726,7 +912,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e025_012750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e025_012750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 26,
@@ -738,7 +931,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e026_013250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e026_013250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 27,
@@ -750,7 +950,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e027_013750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e027_013750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 28,
@@ -762,7 +969,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 45,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e028_014250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e028_014250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 29,
@@ -774,7 +988,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e029_014750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e029_014750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 30,
@@ -786,7 +1007,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e030_015250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e030_015250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 31,
@@ -798,7 +1026,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e031_015750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e031_015750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 32,
@@ -810,7 +1045,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e032_016250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e032_016250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 33,
@@ -822,7 +1064,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e033_016750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e033_016750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 34,
@@ -834,7 +1084,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e034_017250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e034_017250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 35,
@@ -846,7 +1104,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 2,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e035_017750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e035_017750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 36,
@@ -858,7 +1123,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e036_018250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e036_018250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 37,
@@ -870,7 +1142,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e037_018750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e037_018750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 38,
@@ -882,7 +1161,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e038_019250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e038_019250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 39,
@@ -894,7 +1180,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e039_019750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e039_019750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 40,
@@ -906,7 +1199,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e040_020250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e040_020250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 41,
@@ -918,7 +1218,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e041_020750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e041_020750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 42,
@@ -930,7 +1237,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 34,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e042_021250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e042_021250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 43,
@@ -942,7 +1256,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e043_021750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e043_021750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 44,
@@ -954,7 +1275,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e044_022250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e044_022250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 45,
@@ -966,7 +1294,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e045_022750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e045_022750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 46,
@@ -978,7 +1314,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e046_023250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e046_023250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 47,
@@ -990,7 +1333,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e047_023750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e047_023750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 48,
@@ -1002,7 +1352,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 45,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e048_024250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e048_024250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 49,
@@ -1014,7 +1372,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 58,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e049_024750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e049_024750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 50,
@@ -1026,7 +1392,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e050_025250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e050_025250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 51,
@@ -1038,7 +1411,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e051_025750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e051_025750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 52,
@@ -1050,7 +1430,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 42,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e052_026250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e052_026250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 53,
@@ -1062,7 +1450,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 42,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e053_026750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e053_026750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 54,
@@ -1074,7 +1470,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 24,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e054_027250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e054_027250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 55,
@@ -1086,7 +1490,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 24,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e055_027750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e055_027750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 56,
@@ -1098,7 +1509,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 56,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e056_028250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e056_028250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 57,
@@ -1110,7 +1529,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 29,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e057_028750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e057_028750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 58,
@@ -1122,7 +1548,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 2,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e058_029250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e058_029250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 59,
@@ -1134,7 +1567,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 2,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e059_029750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e059_029750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 60,
@@ -1146,7 +1586,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 53,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e060_030250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e060_030250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 61,
@@ -1158,7 +1605,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 2,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e061_030750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e061_030750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 62,
@@ -1170,7 +1624,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e062_031250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e062_031250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 63,
@@ -1182,7 +1643,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 32,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e063_031750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e063_031750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 64,
@@ -1194,7 +1662,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 1,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e064_032250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e064_032250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 65,
@@ -1206,7 +1681,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e065_032750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e065_032750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 66,
@@ -1218,7 +1701,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e066_033250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e066_033250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 67,
@@ -1230,7 +1720,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e067_033750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e067_033750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 68,
@@ -1242,7 +1739,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e068_034250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e068_034250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 69,
@@ -1254,7 +1758,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e069_034750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e069_034750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 70,
@@ -1266,7 +1777,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e070_035250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e070_035250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 71,
@@ -1278,7 +1796,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e071_035750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e071_035750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 72,
@@ -1290,7 +1815,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e072_036250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e072_036250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 73,
@@ -1302,7 +1834,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e073_036750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e073_036750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 74,
@@ -1314,7 +1853,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e074_037250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e074_037250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 75,
@@ -1326,7 +1872,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 68,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e075_037750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e075_037750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 76,
@@ -1338,7 +1891,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e076_038250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e076_038250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 77,
@@ -1350,7 +1910,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e077_038750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e077_038750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 78,
@@ -1362,7 +1929,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e078_039250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e078_039250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 79,
@@ -1374,7 +1948,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e079_039750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e079_039750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 80,
@@ -1386,7 +1967,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e080_040250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e080_040250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 82,
@@ -1398,7 +1986,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e082_041250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e082_041250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 83,
@@ -1410,7 +2005,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e083_041750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e083_041750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 84,
@@ -1422,7 +2024,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 65,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e084_042250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e084_042250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 85,
@@ -1434,7 +2043,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 65,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e085_042750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e085_042750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 86,
@@ -1446,7 +2063,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 24,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e086_043250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e086_043250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 87,
@@ -1458,7 +2082,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e087_043750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e087_043750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 88,
@@ -1470,7 +2101,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 68,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e088_044250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e088_044250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 89,
@@ -1482,7 +2120,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 68,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e089_044750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e089_044750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 90,
@@ -1494,7 +2139,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e090_045250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e090_045250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 91,
@@ -1506,7 +2159,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 65,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e091_045750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e091_045750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 92,
@@ -1518,7 +2179,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e092_046250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e092_046250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 93,
@@ -1530,7 +2198,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e093_046750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e093_046750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 94,
@@ -1542,7 +2217,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e094_047250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e094_047250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 95,
@@ -1554,7 +2237,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e095_047750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e095_047750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 96,
@@ -1566,7 +2256,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e096_048250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e096_048250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 97,
@@ -1578,7 +2275,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e097_048750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e097_048750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 98,
@@ -1590,7 +2294,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e098_049250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e098_049250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 99,
@@ -1602,7 +2313,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 1,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e099_049750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e099_049750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 100,
@@ -1614,7 +2333,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 2,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e100_050250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e100_050250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 101,
@@ -1626,7 +2353,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e101_050750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e101_050750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 102,
@@ -1638,7 +2373,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e102_051250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e102_051250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 103,
@@ -1650,7 +2393,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e103_051750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e103_051750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 104,
@@ -1662,7 +2413,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e104_052250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e104_052250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 105,
@@ -1674,7 +2433,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e105_052750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e105_052750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 106,
@@ -1686,7 +2452,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 54,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e106_053250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e106_053250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 107,
@@ -1698,7 +2472,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e107_053750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e107_053750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 108,
@@ -1710,7 +2491,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e108_054250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e108_054250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 109,
@@ -1722,7 +2510,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 56,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e109_054750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e109_054750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 110,
@@ -1734,7 +2529,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 45,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e110_055250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e110_055250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 111,
@@ -1746,7 +2549,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e111_055750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e111_055750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 112,
@@ -1758,7 +2569,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 32,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e112_056250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e112_056250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 113,
@@ -1770,7 +2588,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 32,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e113_056750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e113_056750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 114,
@@ -1782,7 +2607,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 41,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e114_057250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e114_057250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 115,
@@ -1794,7 +2626,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e115_057750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e115_057750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 116,
@@ -1806,7 +2646,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e116_058250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e116_058250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 117,
@@ -1818,7 +2666,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 24,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e117_058750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e117_058750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 118,
@@ -1830,7 +2686,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e118_059250_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e118_059250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 119,
@@ -1842,11 +2706,19 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e119_059750_obj.jpg"
+      "thumb_obj": "v15044gf0000d29l69nog65hkej1drug_e119_059750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     }
   ],
   "cycles": [
-    "Unknown Blue↑ Green↑ Unknown Unknown Blue Unknown Green↓ Blue↓ Blue Unknown Blue Green↑ Green↑ Unknown Unknown Green↑ Green↑ Blue Blue Blue Unknown Unknown↑ Unknown↑ Unknown↓ Blue Blue Blue Green Blue Blue Blue Yellow Blue↑ Blue↑ Unknown Blue Blue Unknown Blue Blue Blue Blue Blue Blue Blue↑ Yellow Yellow Green↓ Unknown↓ Unknown Unknown Unknown↑ Unknown↑ Green↑ Green Green↓ Pink/Magenta Unknown Unknown Unknown Unknown Blue Unknown Green Blue↑ Blue Blue Blue Blue Blue Blue Blue Blue Blue Unknown Blue Blue Blue Blue Blue Blue Blue Green Green↓ Green Yellow Unknown Unknown Unknown↓ Green↑ Blue Blue Yellow↓ Blue Blue Blue Blue Green↓ Blue↑ Blue↑ Blue↑ Unknown↓ Unknown↓ Yellow Pink/Magenta↓ Blue Blue Green Green↓ Unknown↑ Unknown Unknown Green Blue↑ Pink/Magenta↑ Green↑ Yellow↑ Unknown↑"
+    "Unknown V0 Blue↑ V0 Green↑ V0 Unknown V0 Unknown V0 Blue V0 Unknown V0 Green↓ V0 Blue↓ V0 Blue V0 Unknown V0 Blue V0 Green↑ V0 Green↑ V0 Unknown V0 Unknown V0 Green↑ V0 Green↑ V0 Blue V0 Blue V0 Blue V0 Unknown V0 Unknown↑ V0 Unknown↑ V0 Unknown↓ V0 Blue V0 Blue V0 Blue V0 Green V0 Blue V0 Blue V0 Blue V0 Yellow V0 Blue↑ V0 Blue↑ V0 Unknown V0 Blue V0 Blue V0 Unknown V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue↑ V0 Yellow V0 Yellow V0 Green↓ V0 Unknown↓ V0 Unknown V0 Unknown V0 Unknown↑ V0 Unknown↑ V0 Green↑ V0 Green V0 Green↓ V0 Pink/Magenta V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Blue V0 Unknown V0 Green V0 Blue↑ V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Unknown V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Green V0 Green↓ V0 Green V0 Yellow V0 Unknown V0 Unknown V0 Unknown↓ V0 Green↑ V0 Blue V0 Blue V0 Yellow↓ V0 Blue V0 Blue V0 Blue V0 Blue V0 Green↓ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Unknown↓ V0 Unknown↓ V0 Yellow V0 Pink/Magenta↓ V0 Blue V0 Blue V0 Green V0 Green↓ V0 Unknown↑ V0 Unknown V0 Unknown V0 Green V0 Blue↑ V0 Pink/Magenta↑ V0 Green↑ V0 Yellow↑ V0 Unknown↑ V0"
   ],
   "clustering": {
     "eps": 0.34,

--- a/public/sequences_merge/v15044gf0000d2flkovog65hjpqn71f0.json.sequence.json
+++ b/public/sequences_merge/v15044gf0000d2flkovog65hjpqn71f0.json.sequence.json
@@ -174,7 +174,7 @@
     }
   },
   "symbol_seq": "LLKLKKIIKLIEHHKKHEEHEHIIEEIIRHHHEIIIIEHIHIERIPHRRRREKEEKIEEHHEEHEKKKEHHEKKKHKEELEIKRIKHHEKEEKK_KKKKKELLLKKKKKEEIHKEEIIIPHE_WHUKUKHLLPLQELLQHQQQKIL",
-  "symbol_seq_enhanced": "Unknown↑ Unknown Unknown Unknown↑ Unknown↑ Unknown↑ Yellow Yellow Unknown Unknown Yellow Unknown Unknown Unknown Unknown Unknown Yellow↓ Unknown Unknown Unknown↓ Unknown↓ Yellow Yellow Yellow Unknown Unknown Yellow Yellow↓ Yellow↓ Yellow↓ Yellow↓ Yellow Unknown↓ Yellow↓ Yellow↓ Yellow↓ Yellow↓ Unknown Yellow↓ Yellow↓ Yellow↓ Yellow Unknown↑ Yellow↑ Yellow↑ Yellow↑ Yellow↑ Yellow↑ Yellow↑ Yellow↑ Yellow↑ Unknown↑ Unknown↑ Unknown↑ Unknown↑ Unknown↑ Yellow↑ Unknown↑ Unknown↑ Yellow↑ Yellow↑ Unknown↑ Unknown↑ Yellow↑ Unknown↑ Unknown↑ Unknown↑ Unknown↑ Unknown↑ Yellow↑ Yellow↑ Unknown↑ Unknown↑ Unknown↑ Unknown↑ Yellow↓ Unknown↓ Unknown↓ Unknown↑ Unknown↓ Unknown↓ Yellow↓ Unknown↓ Yellow↓ Yellow↓ Unknown↓ Yellow↓ Yellow↓ Unknown↓ Unknown↓ Unknown↓ Unknown↓ Unknown↓ Unknown↓ Yellow↓ Unknown↓ Unknown Unknown↑ Unknown↓ Unknown↓ Unknown↓ Unknown↓ Unknown Unknown Unknown↓ Unknown↓ Unknown↓ Unknown↓ Unknown↓ Unknown↑ Unknown↑ Yellow Yellow↑ Unknown Unknown Unknown Yellow↑ Yellow Yellow Yellow Yellow Unknown Yellow↑ Yellow↑ Unknown Yellow Unknown Yellow Unknown↑ Yellow↑ Unknown↑ Unknown↑ Yellow↑ Unknown↑ Unknown↑ Unknown↓ Unknown↑ Unknown↑ Unknown Unknown Unknown↑ Unknown↑ Unknown Unknown↓ Yellow Unknown↑",
+  "symbol_seq_enhanced": "Unknown↑ V0 Unknown V0 Unknown V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Yellow V0 Yellow V0 Unknown V0 Unknown V0 Yellow V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Yellow↓ V0 Unknown V0 Unknown V0 Unknown↓ V0 Unknown↓ V0 Yellow V0 Yellow V0 Yellow V0 Unknown V0 Unknown V0 Yellow V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow V0 Unknown↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Unknown V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow V0 Unknown↑ V0 Yellow↑ V0 Yellow↑ V0 Yellow↑ V0 Yellow↑ V0 Yellow↑ V0 Yellow↑ V0 Yellow↑ V0 Yellow↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Yellow↑ V0 Unknown↑ V0 Unknown↑ V0 Yellow↑ V0 Yellow↑ V0 Unknown↑ V0 Unknown↑ V0 Yellow↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Yellow↑ V0 Yellow↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Yellow↓ V0 Unknown↓ V0 Unknown↓ V0 Unknown↑ V0 Unknown↓ V0 Unknown↓ V0 Yellow↓ V0 Unknown↓ V0 Yellow↓ V0 Yellow↓ V0 Unknown↓ V0 Yellow↓ V0 Yellow↓ V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Yellow↓ V0 Unknown↓ V0 Unknown V0 Unknown↑ V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Unknown V0 Unknown V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Unknown↑ V0 Unknown↑ V0 Yellow V0 Yellow↑ V0 Unknown V0 Unknown V0 Unknown V0 Yellow↑ V0 Yellow V0 Yellow V0 Yellow V0 Yellow V0 Unknown V0 Yellow↑ V0 Yellow↑ V0 Unknown V0 Yellow V0 Unknown V0 Yellow V0 Unknown↑ V0 Yellow↑ V0 Unknown↑ V0 Unknown↑ V0 Yellow↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↓ V0 Unknown↑ V0 Unknown↑ V0 Unknown V0 Unknown V0 Unknown↑ V0 Unknown↑ V0 Unknown V0 Unknown↓ V0 Yellow V0 Unknown↑ V0",
   "binary_seq": "01111111111111001111110011100000000000000000000000000000000000000000000000000000000011110111110100001111100100000000000000000000000000001110010001",
   "v_threshold": 0.502,
   "events": [
@@ -188,7 +188,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e000_000250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e000_000250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 1,
@@ -200,7 +208,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e001_000750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e001_000750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 2,
@@ -212,7 +227,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e002_001250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e002_001250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 3,
@@ -224,7 +246,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e003_001750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e003_001750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 4,
@@ -236,7 +266,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e004_002250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e004_002250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 5,
@@ -248,7 +286,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e005_002750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e005_002750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 6,
@@ -260,7 +306,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e006_003250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e006_003250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 7,
@@ -272,7 +325,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e007_003750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e007_003750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 8,
@@ -284,7 +344,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e008_004250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e008_004250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 9,
@@ -296,7 +363,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e009_004750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e009_004750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 10,
@@ -308,7 +382,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e010_005250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e010_005250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 11,
@@ -320,7 +401,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e011_005750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e011_005750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 12,
@@ -332,7 +420,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e012_006250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e012_006250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 13,
@@ -344,7 +439,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e013_006750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e013_006750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 14,
@@ -356,7 +458,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e014_007250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e014_007250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 15,
@@ -368,7 +477,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e015_007750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e015_007750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 16,
@@ -380,7 +496,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e016_008250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e016_008250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 17,
@@ -392,7 +516,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e017_008750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e017_008750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 18,
@@ -404,7 +535,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e018_009250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e018_009250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 19,
@@ -416,7 +554,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e019_009750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e019_009750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 20,
@@ -428,7 +574,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e020_010250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e020_010250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 21,
@@ -440,7 +594,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e021_010750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e021_010750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 22,
@@ -452,7 +613,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e022_011250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e022_011250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 23,
@@ -464,7 +632,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e023_011750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e023_011750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 24,
@@ -476,7 +651,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e024_012250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e024_012250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 25,
@@ -488,7 +670,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e025_012750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e025_012750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 26,
@@ -500,7 +689,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e026_013250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e026_013250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 27,
@@ -512,7 +708,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e027_013750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e027_013750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 28,
@@ -524,7 +728,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e028_014250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e028_014250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 29,
@@ -536,7 +748,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e029_014750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e029_014750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 30,
@@ -548,7 +768,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e030_015250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e030_015250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 31,
@@ -560,7 +788,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e031_015750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e031_015750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 32,
@@ -572,7 +807,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e032_016250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e032_016250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 33,
@@ -584,7 +827,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e033_016750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e033_016750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 34,
@@ -596,7 +847,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e034_017250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e034_017250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 35,
@@ -608,7 +867,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e035_017750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e035_017750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 36,
@@ -620,7 +887,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e036_018250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e036_018250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 37,
@@ -632,7 +907,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e037_018750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e037_018750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 38,
@@ -644,7 +926,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e038_019250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e038_019250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 39,
@@ -656,7 +946,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e039_019750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e039_019750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 40,
@@ -668,7 +966,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e040_020250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e040_020250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 41,
@@ -680,7 +986,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e041_020750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e041_020750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 42,
@@ -692,7 +1005,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e042_021250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e042_021250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 43,
@@ -704,7 +1025,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e043_021750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e043_021750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 44,
@@ -716,7 +1045,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e044_022250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e044_022250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 45,
@@ -728,7 +1065,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e045_022750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e045_022750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 46,
@@ -740,7 +1085,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e046_023250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e046_023250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 47,
@@ -752,7 +1105,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e047_023750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e047_023750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 48,
@@ -764,7 +1125,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e048_024250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e048_024250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 49,
@@ -776,7 +1145,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e049_024750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e049_024750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 50,
@@ -788,7 +1165,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e050_025250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e050_025250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 51,
@@ -800,7 +1185,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e051_025750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e051_025750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 52,
@@ -812,7 +1205,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e052_026250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e052_026250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 53,
@@ -824,7 +1225,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e053_026750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e053_026750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 54,
@@ -836,7 +1245,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e054_027250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e054_027250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 55,
@@ -848,7 +1265,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e055_027750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e055_027750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 56,
@@ -860,7 +1285,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e056_028250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e056_028250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 57,
@@ -872,7 +1305,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e057_028750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e057_028750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 58,
@@ -884,7 +1325,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e058_029250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e058_029250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 59,
@@ -896,7 +1345,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e059_029750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e059_029750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 60,
@@ -908,7 +1365,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e060_030250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e060_030250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 61,
@@ -920,7 +1385,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e061_030750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e061_030750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 62,
@@ -932,7 +1405,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e062_031250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e062_031250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 63,
@@ -944,7 +1425,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e063_031750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e063_031750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 64,
@@ -956,7 +1445,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e064_032250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e064_032250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 65,
@@ -968,7 +1465,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e065_032750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e065_032750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 66,
@@ -980,7 +1485,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e066_033250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e066_033250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 67,
@@ -992,7 +1505,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e067_033750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e067_033750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 68,
@@ -1004,7 +1525,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e068_034250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e068_034250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 69,
@@ -1016,7 +1545,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e069_034750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e069_034750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 70,
@@ -1028,7 +1565,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e070_035250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e070_035250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 71,
@@ -1040,7 +1585,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e071_035750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e071_035750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 72,
@@ -1052,7 +1605,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e072_036250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e072_036250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 73,
@@ -1064,7 +1625,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e073_036750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e073_036750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 74,
@@ -1076,7 +1645,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e074_037250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e074_037250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 75,
@@ -1088,7 +1665,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e075_037750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e075_037750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 76,
@@ -1100,7 +1685,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e076_038250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e076_038250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 77,
@@ -1112,7 +1705,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e077_038750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e077_038750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 78,
@@ -1124,7 +1725,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e078_039250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e078_039250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 79,
@@ -1136,7 +1745,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e079_039750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e079_039750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 80,
@@ -1148,7 +1765,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e080_040250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e080_040250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 81,
@@ -1160,7 +1785,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e081_040750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e081_040750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 82,
@@ -1172,7 +1805,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e082_041250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e082_041250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 83,
@@ -1184,7 +1825,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e083_041750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e083_041750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 84,
@@ -1196,7 +1845,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e084_042250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e084_042250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 85,
@@ -1208,7 +1865,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e085_042750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e085_042750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 86,
@@ -1220,7 +1885,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e086_043250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e086_043250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 87,
@@ -1232,7 +1905,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e087_043750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e087_043750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 88,
@@ -1244,7 +1925,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e088_044250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e088_044250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 89,
@@ -1256,7 +1945,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e089_044750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e089_044750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 90,
@@ -1268,7 +1965,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e090_045250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e090_045250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 91,
@@ -1280,7 +1985,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e091_045750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e091_045750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 92,
@@ -1292,7 +2005,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e092_046250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e092_046250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 93,
@@ -1304,7 +2025,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e093_046750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e093_046750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 94,
@@ -1316,7 +2045,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": -9,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e094_047250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e094_047250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 95,
@@ -1328,7 +2065,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e095_047750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e095_047750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 96,
@@ -1340,7 +2085,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e096_048250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e096_048250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 97,
@@ -1352,7 +2104,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e097_048750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e097_048750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 98,
@@ -1364,7 +2124,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e098_049250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e098_049250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 99,
@@ -1376,7 +2144,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e099_049750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e099_049750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 100,
@@ -1388,7 +2164,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e100_050250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e100_050250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 101,
@@ -1400,7 +2184,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e101_050750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e101_050750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 102,
@@ -1412,7 +2204,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e102_051250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e102_051250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 103,
@@ -1424,7 +2223,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e103_051750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e103_051750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 104,
@@ -1436,7 +2242,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e104_052250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e104_052250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 105,
@@ -1448,7 +2262,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e105_052750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e105_052750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 106,
@@ -1460,7 +2282,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e106_053250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e106_053250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 107,
@@ -1472,7 +2302,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e107_053750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e107_053750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 108,
@@ -1484,7 +2322,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e108_054250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e108_054250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 109,
@@ -1496,7 +2342,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e109_054750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e109_054750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 110,
@@ -1508,7 +2362,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e110_055250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e110_055250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 111,
@@ -1520,7 +2382,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e111_055750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e111_055750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 112,
@@ -1532,7 +2401,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e112_056250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e112_056250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 113,
@@ -1544,7 +2421,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e113_056750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e113_056750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 114,
@@ -1556,7 +2440,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e114_057250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e114_057250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 115,
@@ -1568,7 +2459,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e115_057750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e115_057750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 116,
@@ -1580,7 +2478,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e116_058250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e116_058250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 117,
@@ -1592,7 +2498,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e117_058750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e117_058750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 118,
@@ -1604,7 +2517,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e118_059250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e118_059250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 119,
@@ -1616,7 +2536,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e119_059750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e119_059750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 120,
@@ -1628,7 +2555,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e120_060250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e120_060250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 121,
@@ -1640,7 +2574,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e121_060750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e121_060750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 122,
@@ -1652,7 +2593,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": -9,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e122_061250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e122_061250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 123,
@@ -1664,7 +2613,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e123_061750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e123_061750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 124,
@@ -1676,7 +2633,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e124_062250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e124_062250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 125,
@@ -1688,7 +2652,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e125_062750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e125_062750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 126,
@@ -1700,7 +2671,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e126_063250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e126_063250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 127,
@@ -1712,7 +2690,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e127_063750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e127_063750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 128,
@@ -1724,7 +2709,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e128_064250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e128_064250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 129,
@@ -1736,7 +2729,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e129_064750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e129_064750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 130,
@@ -1748,7 +2749,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e130_065250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e130_065250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 131,
@@ -1760,7 +2769,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e131_065750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e131_065750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 132,
@@ -1772,7 +2789,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e132_066250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e132_066250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 133,
@@ -1784,7 +2809,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e133_066750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e133_066750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 134,
@@ -1796,7 +2829,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e134_067250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e134_067250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 135,
@@ -1808,7 +2849,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e135_067750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e135_067750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 136,
@@ -1820,7 +2869,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e136_068250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e136_068250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 137,
@@ -1832,7 +2889,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e137_068750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e137_068750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 138,
@@ -1844,7 +2909,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e138_069250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e138_069250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 139,
@@ -1856,7 +2928,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e139_069750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e139_069750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 140,
@@ -1868,7 +2947,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e140_070250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e140_070250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 141,
@@ -1880,7 +2967,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e141_070750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e141_070750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 142,
@@ -1892,7 +2987,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e142_071250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e142_071250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 143,
@@ -1904,7 +3006,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e143_071750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e143_071750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 144,
@@ -1916,7 +3026,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e144_072250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e144_072250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 145,
@@ -1928,11 +3045,19 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e145_072750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2flkovog65hjpqn71f0_e145_072750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     }
   ],
   "cycles": [
-    "Unknown↑ Unknown Unknown Unknown↑ Unknown↑ Unknown↑ Yellow Yellow Unknown Unknown Yellow Unknown Unknown Unknown Unknown Unknown Yellow↓ Unknown Unknown Unknown↓ Unknown↓ Yellow Yellow Yellow Unknown Unknown Yellow Yellow↓ Yellow↓ Yellow↓ Yellow↓ Yellow Unknown↓ Yellow↓ Yellow↓ Yellow↓ Yellow↓ Unknown Yellow↓ Yellow↓ Yellow↓ Yellow Unknown↑ Yellow↑ Yellow↑ Yellow↑ Yellow↑ Yellow↑ Yellow↑ Yellow↑ Yellow↑ Unknown↑ Unknown↑ Unknown↑ Unknown↑ Unknown↑ Yellow↑ Unknown↑ Unknown↑ Yellow↑ Yellow↑ Unknown↑ Unknown↑ Yellow↑ Unknown↑ Unknown↑ Unknown↑ Unknown↑ Unknown↑ Yellow↑ Yellow↑ Unknown↑ Unknown↑ Unknown↑ Unknown↑ Yellow↓ Unknown↓ Unknown↓ Unknown↑ Unknown↓ Unknown↓ Yellow↓ Unknown↓ Yellow↓ Yellow↓ Unknown↓ Yellow↓ Yellow↓ Unknown↓ Unknown↓ Unknown↓ Unknown↓ Unknown↓ Unknown↓ Yellow↓ Unknown↓ Unknown Unknown↑ Unknown↓ Unknown↓ Unknown↓ Unknown↓ Unknown Unknown Unknown↓ Unknown↓ Unknown↓ Unknown↓ Unknown↓ Unknown↑ Unknown↑ Yellow Yellow↑ Unknown Unknown Unknown Yellow↑ Yellow Yellow Yellow Yellow Unknown Yellow↑ Yellow↑ Unknown Yellow Unknown Yellow Unknown↑ Yellow↑ Unknown↑ Unknown↑ Yellow↑ Unknown↑ Unknown↑ Unknown↓ Unknown↑ Unknown↑ Unknown Unknown Unknown↑ Unknown↑ Unknown Unknown↓ Yellow Unknown↑"
+    "Unknown↑ V0 Unknown V0 Unknown V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Yellow V0 Yellow V0 Unknown V0 Unknown V0 Yellow V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Yellow↓ V0 Unknown V0 Unknown V0 Unknown↓ V0 Unknown↓ V0 Yellow V0 Yellow V0 Yellow V0 Unknown V0 Unknown V0 Yellow V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow V0 Unknown↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Unknown V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow V0 Unknown↑ V0 Yellow↑ V0 Yellow↑ V0 Yellow↑ V0 Yellow↑ V0 Yellow↑ V0 Yellow↑ V0 Yellow↑ V0 Yellow↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Yellow↑ V0 Unknown↑ V0 Unknown↑ V0 Yellow↑ V0 Yellow↑ V0 Unknown↑ V0 Unknown↑ V0 Yellow↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Yellow↑ V0 Yellow↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Yellow↓ V0 Unknown↓ V0 Unknown↓ V0 Unknown↑ V0 Unknown↓ V0 Unknown↓ V0 Yellow↓ V0 Unknown↓ V0 Yellow↓ V0 Yellow↓ V0 Unknown↓ V0 Yellow↓ V0 Yellow↓ V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Yellow↓ V0 Unknown↓ V0 Unknown V0 Unknown↑ V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Unknown V0 Unknown V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Unknown↑ V0 Unknown↑ V0 Yellow V0 Yellow↑ V0 Unknown V0 Unknown V0 Unknown V0 Yellow↑ V0 Yellow V0 Yellow V0 Yellow V0 Yellow V0 Unknown V0 Yellow↑ V0 Yellow↑ V0 Unknown V0 Yellow V0 Unknown V0 Yellow V0 Unknown↑ V0 Yellow↑ V0 Unknown↑ V0 Unknown↑ V0 Yellow↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↓ V0 Unknown↑ V0 Unknown↑ V0 Unknown V0 Unknown V0 Unknown↑ V0 Unknown↑ V0 Unknown V0 Unknown↓ V0 Yellow V0 Unknown↑ V0"
   ],
   "clustering": {
     "eps": 0.34,

--- a/public/sequences_merge/v15044gf0000d2fr3lfog65rbo3ud6jg.json.sequence.json
+++ b/public/sequences_merge/v15044gf0000d2fr3lfog65rbo3ud6jg.json.sequence.json
@@ -191,7 +191,7 @@
     }
   },
   "symbol_seq": "JABBMGABAAKJBBAAEBBJJCBBAIJSAXGM",
-  "symbol_seq_enhanced": "Blue Pink/Magenta Blue Blue Blue Pink/Magenta Blue Pink/Magenta Blue Blue Blue Blue Blue Blue Blue Blue Blue Blue Blue Blue Pink/Magenta↑ Blue Unknown Unknown Blue Blue",
+  "symbol_seq_enhanced": "Blue V0 Pink/Magenta V0 Blue V0 Blue V0 Blue V0 Pink/Magenta V0 Blue V0 Pink/Magenta V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Pink/Magenta↑ V0 Blue V0 Unknown V0 Unknown V0 Blue V0 Blue V0",
   "binary_seq": "00010000011011100011100100",
   "v_threshold": 0.554,
   "events": [
@@ -205,7 +205,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e000_000250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e000_000250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 1,
@@ -217,7 +224,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 44,
-      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e001_000750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e001_000750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 2,
@@ -229,7 +243,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e002_001250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e002_001250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 3,
@@ -241,7 +262,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e003_001750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e003_001750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 4,
@@ -253,7 +281,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e004_002250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e004_002250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 5,
@@ -265,7 +300,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 44,
-      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e005_002750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e005_002750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 6,
@@ -277,7 +319,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e006_003250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e006_003250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 7,
@@ -289,7 +338,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 29,
-      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e007_003750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e007_003750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 8,
@@ -301,7 +357,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e008_004250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e008_004250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 9,
@@ -313,7 +376,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e009_004750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e009_004750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 10,
@@ -325,7 +395,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e010_005250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e010_005250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 11,
@@ -337,7 +414,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e011_005750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e011_005750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 12,
@@ -349,7 +433,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 34,
-      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e012_006250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e012_006250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 13,
@@ -361,7 +452,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e013_006750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e013_006750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 14,
@@ -373,7 +471,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e014_007250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e014_007250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 15,
@@ -385,7 +490,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e015_007750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e015_007750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 16,
@@ -397,7 +509,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e016_008250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e016_008250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 17,
@@ -409,7 +528,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e017_008750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e017_008750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 18,
@@ -421,7 +547,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e018_009250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e018_009250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 19,
@@ -433,7 +566,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e019_009750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e019_009750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 20,
@@ -445,7 +585,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 67,
-      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e020_010250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e020_010250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 21,
@@ -457,7 +605,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e021_010750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e021_010750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 22,
@@ -469,7 +624,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e022_011250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e022_011250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 23,
@@ -481,7 +643,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 50,
-      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e023_011750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e023_011750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 24,
@@ -493,7 +662,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e024_012250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e024_012250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 25,
@@ -505,11 +681,18 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e025_012750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2fr3lfog65rbo3ud6jg_e025_012750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     }
   ],
   "cycles": [
-    "Blue Pink/Magenta Blue Blue Blue Pink/Magenta Blue Pink/Magenta Blue Blue Blue Blue Blue Blue Blue Blue Blue Blue Blue Blue Pink/Magenta↑ Blue Unknown Unknown Blue Blue"
+    "Blue V0 Pink/Magenta V0 Blue V0 Blue V0 Blue V0 Pink/Magenta V0 Blue V0 Pink/Magenta V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Pink/Magenta↑ V0 Blue V0 Unknown V0 Unknown V0 Blue V0 Blue V0"
   ],
   "clustering": {
     "eps": 0.34,

--- a/public/sequences_merge/v15044gf0000d2ftmcfog65g2pr51j70.json.sequence.json
+++ b/public/sequences_merge/v15044gf0000d2ftmcfog65g2pr51j70.json.sequence.json
@@ -310,7 +310,7 @@
     }
   },
   "symbol_seq": "OVVDAJVAMAW_EAKKSSPAMAJALAEQANLADLKAVYBBSSALAOAMZLAMSSACPAJ",
-  "symbol_seq_enhanced": "Blue Pink/Magenta Pink/Magenta Blue↓ Unknown Pink/Magenta↓ Unknown↓ Unknown↑ Green Unknown↑ Pink/Magenta Unknown↑ Unknown Unknown Yellow↑ Unknown↑ Green Green↓ Blue↓ Unknown Unknown↑ Unknown Yellow↑ Unknown↑ Unknown↓ Unknown↑ Unknown Green Unknown Unknown Green Green Unknown↑ Unknown↓ Unknown↓ Unknown↓ Unknown↓ Unknown↓ Pink/Magenta↓ Yellow↑ Green↑",
+  "symbol_seq_enhanced": "Blue V0 Pink/Magenta V0 Pink/Magenta V0 Blue↓ V0 Unknown V0 Pink/Magenta↓ V0 Unknown↓ V0 Unknown↑ V0 Green V0 Unknown↑ V0 Pink/Magenta V0 Unknown↑ V0 Unknown V0 Unknown V0 Yellow↑ V0 Unknown↑ V0 Green V0 Green↓ V0 Blue↓ V0 Unknown V0 Unknown↑ V0 Unknown V0 Yellow↑ V0 Unknown↑ V0 Unknown↓ V0 Unknown↑ V0 Unknown V0 Green V0 Unknown V0 Unknown V0 Green V0 Green V0 Unknown↑ V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Pink/Magenta↓ V0 Yellow↑ V0 Green↑ V0",
   "binary_seq": "10001000001000110001001000001110100000000",
   "v_threshold": 0.444,
   "events": [
@@ -324,7 +324,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e000_000250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e000_000250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 1,
@@ -336,7 +343,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e001_000750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e001_000750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 2,
@@ -348,7 +362,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e002_001250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e002_001250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 3,
@@ -360,7 +381,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e003_001750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e003_001750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 4,
@@ -372,7 +401,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 24,
-      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e004_002250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e004_002250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 5,
@@ -384,7 +420,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e005_002750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e005_002750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 6,
@@ -396,7 +440,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 7,
-      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e006_003250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e006_003250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 7,
@@ -408,7 +460,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 58,
-      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e007_003750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e007_003750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 8,
@@ -420,7 +480,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": -7,
-      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e008_004250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e008_004250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 9,
@@ -432,7 +499,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e009_004750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e009_004750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 10,
@@ -444,7 +519,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 29,
-      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e010_005250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e010_005250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 11,
@@ -456,7 +538,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e011_005750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e011_005750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 12,
@@ -468,7 +558,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e012_006250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e012_006250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 13,
@@ -480,7 +577,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e013_006750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e013_006750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 14,
@@ -492,7 +596,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e014_007250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e014_007250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 15,
@@ -504,7 +616,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 7,
-      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e015_007750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e015_007750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 16,
@@ -516,7 +636,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 24,
-      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e016_008250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e016_008250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 17,
@@ -528,7 +655,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 1,
-      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e017_008750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e017_008750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 18,
@@ -540,7 +675,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 34,
-      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e018_009250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e018_009250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 19,
@@ -552,7 +695,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e019_009750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e019_009750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 20,
@@ -564,7 +714,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 27,
-      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e020_010250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e020_010250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 21,
@@ -576,7 +734,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e021_010750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e021_010750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 22,
@@ -588,7 +753,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 5,
-      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e022_011250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e022_011250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 23,
@@ -600,7 +773,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e023_011750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e023_011750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 24,
@@ -612,7 +793,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e024_012250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e024_012250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 25,
@@ -624,7 +813,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 53,
-      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e025_012750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e025_012750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 26,
@@ -636,7 +833,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e026_013250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e026_013250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 27,
@@ -648,7 +852,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 66,
-      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e027_013750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e027_013750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 28,
@@ -660,7 +871,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e028_014250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e028_014250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 29,
@@ -672,7 +890,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e029_014750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e029_014750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 30,
@@ -684,7 +909,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 1,
-      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e030_015250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e030_015250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 31,
@@ -696,7 +928,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 41,
-      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e031_015750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e031_015750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 32,
@@ -708,7 +947,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 7,
-      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e032_016250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e032_016250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 33,
@@ -720,7 +967,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 49,
-      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e033_016750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e033_016750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 34,
@@ -732,7 +987,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e034_017250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e034_017250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 35,
@@ -744,7 +1007,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 7,
-      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e035_017750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e035_017750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 36,
@@ -756,7 +1027,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e036_018250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e036_018250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 37,
@@ -768,7 +1047,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e037_018750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e037_018750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 38,
@@ -780,7 +1067,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 38,
-      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e038_019250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e038_019250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 39,
@@ -792,7 +1087,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e039_019750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e039_019750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 40,
@@ -804,11 +1107,19 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 24,
-      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e040_020242_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ftmcfog65g2pr51j70_e040_020242_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     }
   ],
   "cycles": [
-    "Blue Pink/Magenta Pink/Magenta Blue↓ Unknown Pink/Magenta↓ Unknown↓ Unknown↑ Green Unknown↑ Pink/Magenta Unknown↑ Unknown Unknown Yellow↑ Unknown↑ Green Green↓ Blue↓ Unknown Unknown↑ Unknown Yellow↑ Unknown↑ Unknown↓ Unknown↑ Unknown Green Unknown Unknown Green Green Unknown↑ Unknown↓ Unknown↓ Unknown↓ Unknown↓ Unknown↓ Pink/Magenta↓ Yellow↑ Green↑"
+    "Blue V0 Pink/Magenta V0 Pink/Magenta V0 Blue↓ V0 Unknown V0 Pink/Magenta↓ V0 Unknown↓ V0 Unknown↑ V0 Green V0 Unknown↑ V0 Pink/Magenta V0 Unknown↑ V0 Unknown V0 Unknown V0 Yellow↑ V0 Unknown↑ V0 Green V0 Green↓ V0 Blue↓ V0 Unknown V0 Unknown↑ V0 Unknown V0 Yellow↑ V0 Unknown↑ V0 Unknown↓ V0 Unknown↑ V0 Unknown V0 Green V0 Unknown V0 Unknown V0 Green V0 Green V0 Unknown↑ V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Pink/Magenta↓ V0 Yellow↑ V0 Green↑ V0"
   ],
   "clustering": {
     "eps": 0.34,

--- a/public/sequences_merge/v15044gf0000d2gk20nog65g267kppig.json.sequence.json
+++ b/public/sequences_merge/v15044gf0000d2gk20nog65g267kppig.json.sequence.json
@@ -378,7 +378,7 @@
     }
   },
   "symbol_seq": "JAKCZZASAIPM_DTTARAEAEOZZAKABGAEABAITZJCABAICTJJAANAEAEZAFOASAAHAHAHAIAQABJAPMAWAJAHTAFARAFAHBTTNAHAXABAB",
-  "symbol_seq_enhanced": "Blue Pink/Magenta Blue↓ Unknown Unknown Unknown Pink/Magenta Yellow Blue↓ Blue↑ Blue Pink/Magenta↑ Pink/Magenta↑ Unknown↑ Blue↑ Blue↑ Blue↑ Unknown Unknown Pink/Magenta↑ Pink/Magenta↓ Blue Blue↓ Pink/Magenta↓ Pink/Magenta Pink/Magenta Blue Blue↓ Blue Pink/Magenta Pink/Magenta Blue Pink/Magenta↓ Blue↑ Blue↑ Blue↓ Unknown↓ Blue Blue↑ Blue Pink/Magenta↑ Blue Unknown↓ Blue Pink/Magenta Pink/Magenta Unknown↓ Pink/Magenta Green↓ Pink/Magenta Blue↓ Unknown↓ Blue↑ Unknown↓ Green Pink/Magenta Pink/Magenta Pink/Magenta Unknown Pink/Magenta Pink/Magenta Blue↓ Pink/Magenta↓ Pink/Magenta↓ Blue↑ Unknown↓ Unknown↑ Pink/Magenta Pink/Magenta",
+  "symbol_seq_enhanced": "Blue V0 Pink/Magenta V0 Blue↓ V0 Unknown V0 Unknown V0 Unknown V0 Pink/Magenta V0 Yellow V0 Blue↓ V0 Blue↑ V0 Blue V0 Pink/Magenta↑ V0 Pink/Magenta↑ V0 Unknown↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Unknown V0 Unknown V0 Pink/Magenta↑ V0 Pink/Magenta↓ V0 Blue V0 Blue↓ V0 Pink/Magenta↓ V0 Pink/Magenta V0 Pink/Magenta V0 Blue V0 Blue↓ V0 Blue V0 Pink/Magenta V0 Pink/Magenta V0 Blue V0 Pink/Magenta↓ V0 Blue↑ V0 Blue↑ V0 Blue↓ V0 Unknown↓ V0 Blue V0 Blue↑ V0 Blue V0 Pink/Magenta↑ V0 Blue V0 Unknown↓ V0 Blue V0 Pink/Magenta V0 Pink/Magenta V0 Unknown↓ V0 Pink/Magenta V0 Green↓ V0 Pink/Magenta V0 Blue↓ V0 Unknown↓ V0 Blue↑ V0 Unknown↓ V0 Green V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Unknown V0 Pink/Magenta V0 Pink/Magenta V0 Blue↓ V0 Pink/Magenta↓ V0 Pink/Magenta↓ V0 Blue↑ V0 Unknown↓ V0 Unknown↑ V0 Pink/Magenta V0 Pink/Magenta V0",
   "binary_seq": "101000001010000000000010000000000111010000010000000000000001001101000",
   "v_threshold": 0.6319999999999999,
   "events": [
@@ -392,7 +392,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e000_000250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e000_000250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 1,
@@ -404,7 +411,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 29,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e001_000750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e001_000750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 2,
@@ -416,7 +430,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e002_001250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e002_001250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 3,
@@ -428,7 +450,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 49,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e003_001750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e003_001750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 4,
@@ -440,7 +469,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 49,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e004_002250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e004_002250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 5,
@@ -452,7 +488,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 64,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e005_002750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e005_002750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 6,
@@ -464,7 +507,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 67,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e006_003250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e006_003250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 7,
@@ -476,7 +526,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e007_003750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e007_003750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 8,
@@ -488,7 +545,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e008_004250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e008_004250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 9,
@@ -500,7 +565,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": -1,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e009_004750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e009_004750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 10,
@@ -512,7 +585,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e010_005250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e010_005250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 11,
@@ -524,7 +604,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e011_005750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e011_005750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 12,
@@ -536,7 +624,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e012_006250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e012_006250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 13,
@@ -548,7 +644,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 42,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e013_006750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e013_006750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 14,
@@ -560,7 +664,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 34,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e014_007250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e014_007250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 15,
@@ -572,7 +684,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 34,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e015_007750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e015_007750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 16,
@@ -584,7 +704,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e016_008250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e016_008250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 17,
@@ -596,7 +724,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 49,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e017_008750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e017_008750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 18,
@@ -608,7 +743,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 49,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e018_009250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e018_009250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 19,
@@ -620,7 +762,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 29,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e019_009750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e019_009750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 20,
@@ -632,7 +782,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 44,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e020_010250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e020_010250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 21,
@@ -644,7 +802,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e021_010750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e021_010750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 22,
@@ -656,7 +821,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 34,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e022_011250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e022_011250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 23,
@@ -668,7 +841,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 44,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e023_011750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e023_011750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 24,
@@ -680,7 +861,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 67,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e024_012250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e024_012250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 25,
@@ -692,7 +880,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e025_012750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e025_012750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 26,
@@ -704,7 +899,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 49,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e026_013250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e026_013250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 27,
@@ -716,7 +918,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e027_013750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e027_013750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 28,
@@ -728,7 +938,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e028_014250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e028_014250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 29,
@@ -740,7 +957,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 44,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e029_014750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e029_014750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 30,
@@ -752,7 +976,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 67,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e030_015250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e030_015250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 31,
@@ -764,7 +995,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e031_015750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e031_015750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 32,
@@ -776,7 +1014,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e032_016250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e032_016250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 33,
@@ -788,7 +1034,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e033_016750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e033_016750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 34,
@@ -800,7 +1054,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e034_017250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e034_017250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 35,
@@ -812,7 +1074,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e035_017750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e035_017750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 36,
@@ -824,7 +1094,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 27,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e036_018250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e036_018250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 37,
@@ -836,7 +1114,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 34,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e037_018750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e037_018750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 38,
@@ -848,7 +1133,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 34,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e038_019250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e038_019250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 39,
@@ -860,7 +1153,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 49,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e039_019750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e039_019750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 40,
@@ -872,7 +1172,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 54,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e040_020250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e040_020250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 41,
@@ -884,7 +1192,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e041_020750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e041_020750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 42,
@@ -896,7 +1211,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 64,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e042_021250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e042_021250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 43,
@@ -908,7 +1231,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e043_021750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e043_021750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 44,
@@ -920,7 +1250,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 31,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e044_022250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e044_022250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 45,
@@ -932,7 +1269,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 31,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e045_022750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e045_022750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 46,
@@ -944,7 +1288,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 31,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e046_023250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e046_023250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 47,
@@ -956,7 +1308,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 67,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e047_023750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e047_023750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 48,
@@ -968,7 +1327,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 65,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e048_024250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e048_024250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 49,
@@ -980,7 +1347,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 44,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e049_024750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e049_024750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 50,
@@ -992,7 +1366,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e050_025250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e050_025250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 51,
@@ -1004,7 +1386,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 9,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e051_025750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e051_025750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 52,
@@ -1016,7 +1406,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e052_026250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e052_026250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 53,
@@ -1028,7 +1426,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 58,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e053_026750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e053_026750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 54,
@@ -1040,7 +1446,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 24,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e054_027250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e054_027250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 55,
@@ -1052,7 +1465,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 31,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e055_027750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e055_027750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 56,
@@ -1064,7 +1484,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e056_028250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e056_028250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 57,
@@ -1076,7 +1503,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 54,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e057_028750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e057_028750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 58,
@@ -1088,7 +1522,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 42,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e058_029250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e058_029250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 59,
@@ -1100,7 +1541,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 54,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e059_029750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e059_029750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 60,
@@ -1112,7 +1560,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 31,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e060_030250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e060_030250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 61,
@@ -1124,7 +1579,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e061_030750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e061_030750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 62,
@@ -1136,7 +1599,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e062_031250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e062_031250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 63,
@@ -1148,7 +1619,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e063_031750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e063_031750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 64,
@@ -1160,7 +1639,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e064_032250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e064_032250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 65,
@@ -1172,7 +1659,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 31,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e065_032750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e065_032750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 66,
@@ -1184,7 +1679,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 50,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e066_033250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e066_033250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 67,
@@ -1196,7 +1699,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 44,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e067_033750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e067_033750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 68,
@@ -1208,11 +1718,18 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 44,
-      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e068_034250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gk20nog65g267kppig_e068_034250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     }
   ],
   "cycles": [
-    "Blue Pink/Magenta Blue↓ Unknown Unknown Unknown Pink/Magenta Yellow Blue↓ Blue↑ Blue Pink/Magenta↑ Pink/Magenta↑ Unknown↑ Blue↑ Blue↑ Blue↑ Unknown Unknown Pink/Magenta↑ Pink/Magenta↓ Blue Blue↓ Pink/Magenta↓ Pink/Magenta Pink/Magenta Blue Blue↓ Blue Pink/Magenta Pink/Magenta Blue Pink/Magenta↓ Blue↑ Blue↑ Blue↓ Unknown↓ Blue Blue↑ Blue Pink/Magenta↑ Blue Unknown↓ Blue Pink/Magenta Pink/Magenta Unknown↓ Pink/Magenta Green↓ Pink/Magenta Blue↓ Unknown↓ Blue↑ Unknown↓ Green Pink/Magenta Pink/Magenta Pink/Magenta Unknown Pink/Magenta Pink/Magenta Blue↓ Pink/Magenta↓ Pink/Magenta↓ Blue↑ Unknown↓ Unknown↑ Pink/Magenta Pink/Magenta"
+    "Blue V0 Pink/Magenta V0 Blue↓ V0 Unknown V0 Unknown V0 Unknown V0 Pink/Magenta V0 Yellow V0 Blue↓ V0 Blue↑ V0 Blue V0 Pink/Magenta↑ V0 Pink/Magenta↑ V0 Unknown↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Unknown V0 Unknown V0 Pink/Magenta↑ V0 Pink/Magenta↓ V0 Blue V0 Blue↓ V0 Pink/Magenta↓ V0 Pink/Magenta V0 Pink/Magenta V0 Blue V0 Blue↓ V0 Blue V0 Pink/Magenta V0 Pink/Magenta V0 Blue V0 Pink/Magenta↓ V0 Blue↑ V0 Blue↑ V0 Blue↓ V0 Unknown↓ V0 Blue V0 Blue↑ V0 Blue V0 Pink/Magenta↑ V0 Blue V0 Unknown↓ V0 Blue V0 Pink/Magenta V0 Pink/Magenta V0 Unknown↓ V0 Pink/Magenta V0 Green↓ V0 Pink/Magenta V0 Blue↓ V0 Unknown↓ V0 Blue↑ V0 Unknown↓ V0 Green V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Unknown V0 Pink/Magenta V0 Pink/Magenta V0 Blue↓ V0 Pink/Magenta↓ V0 Pink/Magenta↓ V0 Blue↑ V0 Unknown↓ V0 Unknown↑ V0 Pink/Magenta V0 Pink/Magenta V0"
   ],
   "clustering": {
     "eps": 0.34,

--- a/public/sequences_merge/v15044gf0000d2gkmqvog65j2bgtitqg.json.sequence.json
+++ b/public/sequences_merge/v15044gf0000d2gkmqvog65j2bgtitqg.json.sequence.json
@@ -276,7 +276,7 @@
     }
   },
   "symbol_seq": "DDOAACDALALOJSFFOSXFFDACACSABAGDJSSAGCDAABBBACAFSAGCATATABABVVVYOOORNNFAXAXBABAVAAOASBCFFSOJNVD",
-  "symbol_seq_enhanced": "Blue Blue Blue Blue Blue Blue Blue Green Green Blue Blue Unknown Blue Blue Blue Unknown Unknown Blue Blue Blue Pink/Magenta Pink/Magenta Unknown Blue Blue Blue Blue Blue Blue Pink/Magenta Pink/Magenta Blue Blue Blue Blue Blue Pink/Magenta Green↓ Pink/Magenta↑ Pink/Magenta↓ Unknown Pink/Magenta Blue↓ Unknown↓ Unknown↓ Pink/Magenta↑ Blue↓ Blue Pink/Magenta Pink/Magenta Pink/Magenta↑ Unknown Blue Blue Blue Yellow↓ Blue Blue Blue Unknown↓ Unknown↓ Unknown↓ Unknown↓ Pink/Magenta↑ Blue Blue Blue Blue Unknown Green Blue Blue Unknown Blue Blue Blue Pink/Magenta Blue",
+  "symbol_seq_enhanced": "Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Green V0 Green V0 Blue V0 Blue V0 Unknown V0 Blue V0 Blue V0 Blue V0 Unknown V0 Unknown V0 Blue V0 Blue V0 Blue V0 Pink/Magenta V0 Pink/Magenta V0 Unknown V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Pink/Magenta V0 Pink/Magenta V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Pink/Magenta V0 Green↓ V0 Pink/Magenta↑ V0 Pink/Magenta↓ V0 Unknown V0 Pink/Magenta V0 Blue↓ V0 Unknown↓ V0 Unknown↓ V0 Pink/Magenta↑ V0 Blue↓ V0 Blue V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta↑ V0 Unknown V0 Blue V0 Blue V0 Blue V0 Yellow↓ V0 Blue V0 Blue V0 Blue V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Pink/Magenta↑ V0 Blue V0 Blue V0 Blue V0 Blue V0 Unknown V0 Green V0 Blue V0 Blue V0 Unknown V0 Blue V0 Blue V0 Blue V0 Pink/Magenta V0 Blue V0",
   "binary_seq": "000000111010000000001101111010001111000000000001000000000001100011000011011100",
   "v_threshold": 0.534,
   "events": [
@@ -290,7 +290,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e000_000250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e000_000250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 1,
@@ -302,7 +309,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e001_000750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e001_000750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 2,
@@ -314,7 +328,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e002_001250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e002_001250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 3,
@@ -326,7 +347,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e003_001750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e003_001750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 4,
@@ -338,7 +366,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e004_002250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e004_002250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 5,
@@ -350,7 +385,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e005_002750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e005_002750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 6,
@@ -362,7 +404,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e006_003250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e006_003250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 7,
@@ -374,7 +423,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 1,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e007_003750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e007_003750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 8,
@@ -386,7 +442,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 1,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e008_004250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e008_004250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 9,
@@ -398,7 +461,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e009_004750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e009_004750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 10,
@@ -410,7 +480,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e010_005250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e010_005250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 11,
@@ -422,7 +499,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e011_005750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e011_005750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 12,
@@ -434,7 +518,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e012_006250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e012_006250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 13,
@@ -446,7 +537,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e013_006750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e013_006750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 14,
@@ -458,7 +556,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e014_007250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e014_007250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 15,
@@ -470,7 +575,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e015_007750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e015_007750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 16,
@@ -482,7 +594,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 2,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e016_008250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e016_008250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 17,
@@ -494,7 +613,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e017_008750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e017_008750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 18,
@@ -506,7 +632,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e018_009250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e018_009250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 19,
@@ -518,7 +651,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e019_009750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e019_009750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 20,
@@ -530,7 +670,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 38,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e020_010250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e020_010250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 21,
@@ -542,7 +689,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 38,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e021_010750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e021_010750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 22,
@@ -554,7 +708,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e022_011250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e022_011250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 23,
@@ -566,7 +727,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e023_011750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e023_011750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 24,
@@ -578,7 +746,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e024_012250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e024_012250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 25,
@@ -590,7 +765,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e025_012750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e025_012750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 26,
@@ -602,7 +784,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e026_013250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e026_013250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 27,
@@ -614,7 +803,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e027_013750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e027_013750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 28,
@@ -626,7 +822,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e028_014250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e028_014250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 29,
@@ -638,7 +841,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e029_014750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e029_014750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 30,
@@ -650,7 +860,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e030_015250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e030_015250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 31,
@@ -662,7 +879,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e031_015750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e031_015750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 32,
@@ -674,7 +898,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e032_016250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e032_016250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 33,
@@ -686,7 +917,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e033_016750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e033_016750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 34,
@@ -698,7 +936,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e034_017250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e034_017250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 35,
@@ -710,7 +955,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e035_017750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e035_017750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 36,
@@ -722,7 +974,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 44,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e036_018250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e036_018250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 37,
@@ -734,7 +993,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 66,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e037_018750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e037_018750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 38,
@@ -746,7 +1013,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 38,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e038_019250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e038_019250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 39,
@@ -758,7 +1033,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 54,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e039_019750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e039_019750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 40,
@@ -770,7 +1053,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e040_020250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e040_020250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 41,
@@ -782,7 +1072,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 26,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e041_020750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e041_020750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 42,
@@ -794,7 +1091,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e042_021250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e042_021250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 43,
@@ -806,7 +1111,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 32,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e043_021750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e043_021750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 44,
@@ -818,7 +1131,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 32,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e044_022250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e044_022250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 45,
@@ -830,7 +1151,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 44,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e045_022750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e045_022750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 46,
@@ -842,7 +1171,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e046_023250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e046_023250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 47,
@@ -854,7 +1191,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e047_023750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e047_023750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 48,
@@ -866,7 +1210,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e048_024250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e048_024250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 49,
@@ -878,7 +1229,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e049_024750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e049_024750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 50,
@@ -890,7 +1248,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e050_025250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e050_025250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 51,
@@ -902,7 +1268,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e051_025750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e051_025750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 52,
@@ -914,7 +1287,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e052_026250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e052_026250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 53,
@@ -926,7 +1306,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e053_026750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e053_026750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 54,
@@ -938,7 +1325,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e054_027250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e054_027250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 55,
@@ -950,7 +1344,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e055_027750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e055_027750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 56,
@@ -962,7 +1364,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e056_028250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e056_028250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 57,
@@ -974,7 +1383,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e057_028750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e057_028750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 58,
@@ -986,7 +1402,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e058_029250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e058_029250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 59,
@@ -998,7 +1421,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 50,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e059_029750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e059_029750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 60,
@@ -1010,7 +1441,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 50,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e060_030250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e060_030250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 61,
@@ -1022,7 +1461,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 61,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e061_030750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e061_030750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 62,
@@ -1034,7 +1481,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 61,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e062_031250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e062_031250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 63,
@@ -1046,7 +1501,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e063_031750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e063_031750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 64,
@@ -1058,7 +1521,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e064_032250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e064_032250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 65,
@@ -1070,7 +1540,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e065_032750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e065_032750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 66,
@@ -1082,7 +1559,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e066_033250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e066_033250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 67,
@@ -1094,7 +1578,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e067_033750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e067_033750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 68,
@@ -1106,7 +1597,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e068_034250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e068_034250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 69,
@@ -1118,7 +1616,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 69,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e069_034750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e069_034750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 70,
@@ -1130,7 +1635,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e070_035250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e070_035250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 71,
@@ -1142,7 +1654,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e071_035750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e071_035750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 72,
@@ -1154,7 +1673,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e072_036250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e072_036250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 73,
@@ -1166,7 +1692,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e073_036750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e073_036750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 74,
@@ -1178,7 +1711,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e074_037250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e074_037250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 75,
@@ -1190,7 +1730,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e075_037750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e075_037750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 76,
@@ -1202,7 +1749,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e076_038250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e076_038250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 77,
@@ -1214,11 +1768,18 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e077_038750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gkmqvog65j2bgtitqg_e077_038750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     }
   ],
   "cycles": [
-    "Blue Blue Blue Blue Blue Blue Blue Green Green Blue Blue Unknown Blue Blue Blue Unknown Unknown Blue Blue Blue Pink/Magenta Pink/Magenta Unknown Blue Blue Blue Blue Blue Blue Pink/Magenta Pink/Magenta Blue Blue Blue Blue Blue Pink/Magenta Green↓ Pink/Magenta↑ Pink/Magenta↓ Unknown Pink/Magenta Blue↓ Unknown↓ Unknown↓ Pink/Magenta↑ Blue↓ Blue Pink/Magenta Pink/Magenta Pink/Magenta↑ Unknown Blue Blue Blue Yellow↓ Blue Blue Blue Unknown↓ Unknown↓ Unknown↓ Unknown↓ Pink/Magenta↑ Blue Blue Blue Blue Unknown Green Blue Blue Unknown Blue Blue Blue Pink/Magenta Blue"
+    "Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Green V0 Green V0 Blue V0 Blue V0 Unknown V0 Blue V0 Blue V0 Blue V0 Unknown V0 Unknown V0 Blue V0 Blue V0 Blue V0 Pink/Magenta V0 Pink/Magenta V0 Unknown V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Pink/Magenta V0 Pink/Magenta V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Pink/Magenta V0 Green↓ V0 Pink/Magenta↑ V0 Pink/Magenta↓ V0 Unknown V0 Pink/Magenta V0 Blue↓ V0 Unknown↓ V0 Unknown↓ V0 Pink/Magenta↑ V0 Blue↓ V0 Blue V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta↑ V0 Unknown V0 Blue V0 Blue V0 Blue V0 Yellow↓ V0 Blue V0 Blue V0 Blue V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Pink/Magenta↑ V0 Blue V0 Blue V0 Blue V0 Blue V0 Unknown V0 Green V0 Blue V0 Blue V0 Unknown V0 Blue V0 Blue V0 Blue V0 Pink/Magenta V0 Blue V0"
   ],
   "clustering": {
     "eps": 0.34,

--- a/public/sequences_merge/v15044gf0000d2gld7vog65leghdunsg.json.sequence.json
+++ b/public/sequences_merge/v15044gf0000d2gld7vog65leghdunsg.json.sequence.json
@@ -225,7 +225,7 @@
     }
   },
   "symbol_seq": "DACDGGBATACAL_AEAIAZACGXDBAPAEGAGAAAO",
-  "symbol_seq_enhanced": "Blue Pink/Magenta↓ Blue Blue Blue Blue↑ Blue Pink/Magenta Blue↑ Blue Green↓ Unknown↓ Blue↓ Pink/Magenta Unknown↑ Pink/Magenta↓ Blue Blue↑ Blue↑ Green↓ Yellow↓ Blue Blue Pink/Magenta Pink/Magenta↓ Green",
+  "symbol_seq_enhanced": "Blue V0 Pink/Magenta↓ V0 Blue V0 Blue V0 Blue V0 Blue↑ V0 Blue V0 Pink/Magenta V0 Blue↑ V0 Blue V0 Green↓ V0 Unknown↓ V0 Blue↓ V0 Pink/Magenta V0 Unknown↑ V0 Pink/Magenta↓ V0 Blue V0 Blue↑ V0 Blue↑ V0 Green↓ V0 Yellow↓ V0 Blue V0 Blue V0 Pink/Magenta V0 Pink/Magenta↓ V0 Green V0",
   "binary_seq": "00000000100100011101010100",
   "v_threshold": 0.48600000000000004,
   "events": [
@@ -239,7 +239,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e000_001200_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e000_001200_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 1,
@@ -251,7 +258,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 38,
-      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e001_014300_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e001_014300_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 2,
@@ -263,7 +278,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e002_002450_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e002_002450_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 3,
@@ -275,7 +297,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e003_003450_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e003_003450_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 4,
@@ -287,7 +316,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e004_004450_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e004_004450_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 5,
@@ -299,7 +335,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e005_005450_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e005_005450_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 6,
@@ -311,7 +355,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e006_006450_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e006_006450_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 7,
@@ -323,7 +374,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e007_007450_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e007_007450_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 8,
@@ -335,7 +393,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e008_008450_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e008_008450_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 9,
@@ -347,7 +413,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e009_009450_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e009_009450_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 10,
@@ -359,7 +432,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 1,
-      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e010_010450_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e010_010450_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 11,
@@ -371,7 +452,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": -2,
-      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e011_011450_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e011_011450_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 12,
@@ -383,7 +472,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 34,
-      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e012_012450_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e012_012450_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 13,
@@ -395,7 +492,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 67,
-      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e013_013450_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e013_013450_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 14,
@@ -407,7 +511,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 68,
-      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e014_014450_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e014_014450_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 15,
@@ -419,7 +531,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 38,
-      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e015_015450_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e015_015450_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 16,
@@ -431,7 +551,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e016_016450_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e016_016450_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 17,
@@ -443,7 +570,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 2,
-      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e017_017450_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e017_017450_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 18,
@@ -455,7 +590,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e018_018450_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e018_018450_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 19,
@@ -467,7 +610,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 61,
-      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e019_019450_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e019_019450_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 20,
@@ -479,7 +630,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e020_020450_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e020_020450_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 21,
@@ -491,7 +650,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 34,
-      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e021_021450_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e021_021450_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 22,
@@ -503,7 +669,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e022_022450_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e022_022450_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 23,
@@ -515,7 +688,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 26,
-      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e023_023450_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e023_023450_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 24,
@@ -527,7 +707,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 70,
-      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e024_024450_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e024_024450_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 25,
@@ -539,13 +727,20 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 41,
-      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e025_025475_obj.jpg"
+      "thumb_obj": "v15044gf0000d2gld7vog65leghdunsg_e025_025475_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     }
   ],
   "cycles": [
-    "Blue",
-    "Pink/Magenta↓",
-    "Blue Blue Blue Blue↑ Blue Pink/Magenta Blue↑ Blue Green↓ Unknown↓ Blue↓ Pink/Magenta Unknown↑ Pink/Magenta↓ Blue Blue↑ Blue↑ Green↓ Yellow↓ Blue Blue Pink/Magenta Pink/Magenta↓ Green"
+    "Blue V0",
+    "Pink/Magenta↓ V0",
+    "Blue V0 Blue V0 Blue V0 Blue↑ V0 Blue V0 Pink/Magenta V0 Blue↑ V0 Blue V0 Green↓ V0 Unknown↓ V0 Blue↓ V0 Pink/Magenta V0 Unknown↑ V0 Pink/Magenta↓ V0 Blue V0 Blue↑ V0 Blue↑ V0 Green↓ V0 Yellow↓ V0 Blue V0 Blue V0 Pink/Magenta V0 Pink/Magenta↓ V0 Green V0"
   ],
   "clustering": {
     "eps": 0.34,

--- a/public/sequences_merge/v15044gf0000d2hjqh7og65nf6193bh0.json.sequence.json
+++ b/public/sequences_merge/v15044gf0000d2hjqh7og65nf6193bh0.json.sequence.json
@@ -293,7 +293,7 @@
     }
   },
   "symbol_seq": "VBSBTVVVOWAD__AIAA_CUPJAESPAPANANPAEAEMMVMBOBOSBHWBIBIANBNBNAMADADANWBI_BHBHMS__ADADAMAH",
-  "symbol_seq_enhanced": "Pink/Magenta↓ Unknown↓ Unknown↓ Pink/Magenta↑ Pink/Magenta↑ Pink/Magenta↑ Blue Yellow↓ Yellow↓ Unknown↑ Pink/Magenta↓ Pink/Magenta↑ Pink/Magenta↓ Green↓ Blue Yellow Yellow Blue Blue Unknown Yellow Unknown↓ Unknown Unknown↑ Yellow Blue Blue Blue Blue Pink/Magenta Blue Unknown↑ Unknown↑ Unknown Yellow↑ Yellow↑ Unknown↑ Unknown↑ Unknown↑ Yellow Yellow Unknown↑ Yellow Yellow↑ Unknown↑ Yellow↑ Unknown↑ Yellow↑ Yellow↑ Yellow↑ Blue Unknown Unknown↑ Yellow↑ Unknown↑ Yellow Unknown↑ Pink/Magenta↓",
+  "symbol_seq_enhanced": "Pink/Magenta↓ V0 Unknown↓ V0 Unknown↓ V0 Pink/Magenta↑ V0 Pink/Magenta↑ V0 Pink/Magenta↑ V0 Blue V0 Yellow↓ V0 Yellow↓ V0 Unknown↑ V0 Pink/Magenta↓ V0 Pink/Magenta↑ V0 Pink/Magenta↓ V0 Green↓ V0 Blue V0 Yellow V0 Yellow V0 Blue V0 Blue V0 Unknown V0 Yellow V0 Unknown↓ V0 Unknown V0 Unknown↑ V0 Yellow V0 Blue V0 Blue V0 Blue V0 Blue V0 Pink/Magenta V0 Blue V0 Unknown↑ V0 Unknown↑ V0 Unknown V0 Yellow↑ V0 Yellow↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Yellow V0 Yellow V0 Unknown↑ V0 Yellow V0 Yellow↑ V0 Unknown↑ V0 Yellow↑ V0 Unknown↑ V0 Yellow↑ V0 Yellow↑ V0 Yellow↑ V0 Blue V0 Unknown V0 Unknown↑ V0 Yellow↑ V0 Unknown↑ V0 Yellow V0 Unknown↑ V0 Pink/Magenta↓ V0",
   "binary_seq": "0000000000000010011000000111101000000000010000000010000011",
   "v_threshold": 0.5700000000000001,
   "events": [
@@ -307,7 +307,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e000_000250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e000_000250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 1,
@@ -319,7 +327,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 73,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e001_000750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e001_000750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 2,
@@ -331,7 +347,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 72,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e002_001250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e002_001250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 3,
@@ -343,7 +367,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e003_001750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e003_001750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 4,
@@ -355,7 +387,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e004_002250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e004_002250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 5,
@@ -367,7 +407,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e005_002750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e005_002750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 6,
@@ -379,7 +427,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e006_003250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e006_003250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 7,
@@ -391,7 +446,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e007_003750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e007_003750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 8,
@@ -403,7 +466,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 5,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e008_004250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e008_004250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 9,
@@ -415,7 +486,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": -2,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e009_004750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e009_004750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 10,
@@ -427,7 +506,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": -6,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e010_005250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e010_005250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 11,
@@ -439,7 +526,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 67,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e011_005750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e011_005750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 12,
@@ -451,7 +546,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 70,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e012_006250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e012_006250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 13,
@@ -463,7 +566,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": -7,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e013_006750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e013_006750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 14,
@@ -475,7 +586,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e014_007250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e014_007250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 15,
@@ -487,7 +605,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e015_007750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e015_007750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 16,
@@ -499,7 +624,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e016_008250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e016_008250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 17,
@@ -511,7 +643,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e017_008750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e017_008750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 18,
@@ -523,7 +662,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 34,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e018_009250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e018_009250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 19,
@@ -535,7 +681,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e019_009750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e019_009750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 20,
@@ -547,7 +700,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e020_010250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e020_010250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 21,
@@ -559,7 +719,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 9,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e021_010750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e021_010750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 22,
@@ -571,7 +739,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 27,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e022_011250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e022_011250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 23,
@@ -583,7 +758,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 27,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e023_011750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e023_011750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 24,
@@ -595,7 +778,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e024_012250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e024_012250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 25,
@@ -607,7 +797,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 34,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e025_012750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e025_012750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 26,
@@ -619,7 +816,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 34,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e026_013250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e026_013250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 27,
@@ -631,7 +835,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e027_013750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e027_013750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 28,
@@ -643,7 +854,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e028_014250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e028_014250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 29,
@@ -655,7 +873,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e029_014750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e029_014750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 30,
@@ -667,7 +892,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e030_015250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e030_015250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 31,
@@ -679,7 +911,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 10,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e031_015750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e031_015750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 32,
@@ -691,7 +931,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 10,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e032_016250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e032_016250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 33,
@@ -703,7 +951,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e033_016750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e033_016750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 34,
@@ -715,7 +970,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 21,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e034_017250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e034_017250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 35,
@@ -727,7 +990,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e035_017750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e035_017750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 36,
@@ -739,7 +1010,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 11,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e036_018250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e036_018250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 37,
@@ -751,7 +1030,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 11,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e037_018750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e037_018750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 38,
@@ -763,7 +1050,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 27,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e038_019250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e038_019250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 39,
@@ -775,7 +1070,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 6,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e039_019750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e039_019750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 40,
@@ -787,7 +1089,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 6,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e040_020250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e040_020250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 41,
@@ -799,7 +1108,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 7,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e041_020750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e041_020750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 42,
@@ -811,7 +1128,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 5,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e042_021250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e042_021250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 43,
@@ -823,7 +1147,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 5,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e043_021750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e043_021750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 44,
@@ -835,7 +1167,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 27,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e044_022250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e044_022250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 45,
@@ -847,7 +1187,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e045_022750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e045_022750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 46,
@@ -859,7 +1207,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 11,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e046_023250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e046_023250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 47,
@@ -871,7 +1227,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": -9,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e047_023750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e047_023750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 48,
@@ -883,7 +1247,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 21,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e048_024250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e048_024250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 49,
@@ -895,7 +1267,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 21,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e049_024750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e049_024750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 50,
@@ -907,7 +1287,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e050_025250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e050_025250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 51,
@@ -919,7 +1306,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e051_025750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e051_025750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 52,
@@ -931,7 +1325,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": -10,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e052_026250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e052_026250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 53,
@@ -943,7 +1345,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": -8,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e053_026750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e053_026750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 54,
@@ -955,7 +1365,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 5,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e054_027250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e054_027250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 55,
@@ -967,7 +1385,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 5,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e055_027750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e055_027750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 56,
@@ -979,7 +1404,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 7,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e056_028250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e056_028250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 57,
@@ -991,11 +1424,19 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 31,
-      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e057_028750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2hjqh7og65nf6193bh0_e057_028750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     }
   ],
   "cycles": [
-    "Pink/Magenta↓ Unknown↓ Unknown↓ Pink/Magenta↑ Pink/Magenta↑ Pink/Magenta↑ Blue Yellow↓ Yellow↓ Unknown↑ Pink/Magenta↓ Pink/Magenta↑ Pink/Magenta↓ Green↓ Blue Yellow Yellow Blue Blue Unknown Yellow Unknown↓ Unknown Unknown↑ Yellow Blue Blue Blue Blue Pink/Magenta Blue Unknown↑ Unknown↑ Unknown Yellow↑ Yellow↑ Unknown↑ Unknown↑ Unknown↑ Yellow Yellow Unknown↑ Yellow Yellow↑ Unknown↑ Yellow↑ Unknown↑ Yellow↑ Yellow↑ Yellow↑ Blue Unknown Unknown↑ Yellow↑ Unknown↑ Yellow Unknown↑ Pink/Magenta↓"
+    "Pink/Magenta↓ V0 Unknown↓ V0 Unknown↓ V0 Pink/Magenta↑ V0 Pink/Magenta↑ V0 Pink/Magenta↑ V0 Blue V0 Yellow↓ V0 Yellow↓ V0 Unknown↑ V0 Pink/Magenta↓ V0 Pink/Magenta↑ V0 Pink/Magenta↓ V0 Green↓ V0 Blue V0 Yellow V0 Yellow V0 Blue V0 Blue V0 Unknown V0 Yellow V0 Unknown↓ V0 Unknown V0 Unknown↑ V0 Yellow V0 Blue V0 Blue V0 Blue V0 Blue V0 Pink/Magenta V0 Blue V0 Unknown↑ V0 Unknown↑ V0 Unknown V0 Yellow↑ V0 Yellow↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Yellow V0 Yellow V0 Unknown↑ V0 Yellow V0 Yellow↑ V0 Unknown↑ V0 Yellow↑ V0 Unknown↑ V0 Yellow↑ V0 Yellow↑ V0 Yellow↑ V0 Blue V0 Unknown V0 Unknown↑ V0 Yellow↑ V0 Unknown↑ V0 Yellow V0 Unknown↑ V0 Pink/Magenta↓ V0"
   ],
   "clustering": {
     "eps": 0.34,

--- a/public/sequences_merge/v15044gf0000d2ht9mnog65nf61i3sl0.json.sequence.json
+++ b/public/sequences_merge/v15044gf0000d2ht9mnog65nf61i3sl0.json.sequence.json
@@ -429,7 +429,7 @@
     }
   },
   "symbol_seq": "BUBVAFZAAZAFAKAKAHAIAIAAAAACACAGTABAFAIAIBJBJGJCJCDDMGJDBBCBAFGJFFDMMAEFAECAOAMMFMCBYAXALALBAAXAZAVAOXYBBAYAUAZAWAXBABCAWBAARAZAUAQAOAJAJBCAKASASAIALSSAAAAVBABAABWJCAZAJBBAOALAXAQAPEAJZAEGBGGGGCGBAVBCAVGARYMMMAXAEZJZAFJAAACAKAITV",
-  "symbol_seq_enhanced": "Unknown↓ Blue↑ Pink/Magenta↓ Unknown Pink/Magenta Blue↑ Pink/Magenta Pink/Magenta Pink/Magenta Pink/Magenta Pink/Magenta Pink/Magenta Pink/Magenta Pink/Magenta↓ Pink/Magenta↓ Pink/Magenta Pink/Magenta↓ Pink/Magenta Pink/Magenta Pink/Magenta Pink/Magenta Pink/Magenta Blue Blue Blue Blue Blue Blue Blue Blue↑ Blue↑ Blue↑ Blue↑ Blue↑ Blue↑ Blue↑ Blue↑ Blue↑ Blue↑ Blue↑ Blue↑ Blue Blue↑ Blue↑ Blue↑ Blue↑ Blue↑ Blue↑ Blue↑ Blue↑ Blue Blue↑ Blue↑ Blue↑ Blue↑ Blue Blue Blue Blue Blue Blue Unknown↑ Unknown↑ Green Green Green↑ Unknown↑ Unknown↑ Unknown↑ Green↑ Blue↑ Unknown↑ Green↑ Green↑ Green↑ Unknown↑ Unknown↑ Unknown↑ Unknown Green Unknown↑ Green Unknown↑ Unknown Green↑ Green↑ Green↑ Green↑ Green↑ Green↑ Pink/Magenta↓ Unknown Unknown Pink/Magenta Green Unknown↑ Unknown↑ Blue↑ Pink/Magenta Unknown↑ Unknown↑ Unknown↑ Blue Blue Blue Blue Unknown↑ Green Green↑ Green↑ Green↑ Unknown↑ Green↑ Unknown Unknown↑ Green↑ Unknown Blue Blue Blue Blue Blue Blue Blue Blue Blue Blue Unknown Green↑ Unknown Blue Unknown↑ Unknown Blue Blue Blue Unknown Blue Unknown Blue Unknown Pink/Magenta Blue Pink/Magenta Pink/Magenta Pink/Magenta Pink/Magenta Pink/Magenta Pink/Magenta",
+  "symbol_seq_enhanced": "Unknown↓ V0 Blue↑ V0 Pink/Magenta↓ V0 Unknown V0 Pink/Magenta V0 Blue↑ V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta↓ V0 Pink/Magenta↓ V0 Pink/Magenta V0 Pink/Magenta↓ V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Unknown↑ V0 Unknown↑ V0 Green V0 Green V0 Green↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Green↑ V0 Blue↑ V0 Unknown↑ V0 Green↑ V0 Green↑ V0 Green↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown V0 Green V0 Unknown↑ V0 Green V0 Unknown↑ V0 Unknown V0 Green↑ V0 Green↑ V0 Green↑ V0 Green↑ V0 Green↑ V0 Green↑ V0 Pink/Magenta↓ V0 Unknown V0 Unknown V0 Pink/Magenta V0 Green V0 Unknown↑ V0 Unknown↑ V0 Blue↑ V0 Pink/Magenta V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Blue V0 Blue V0 Blue V0 Blue V0 Unknown↑ V0 Green V0 Green↑ V0 Green↑ V0 Green↑ V0 Unknown↑ V0 Green↑ V0 Unknown V0 Unknown↑ V0 Green↑ V0 Unknown V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Unknown V0 Green↑ V0 Unknown V0 Blue V0 Unknown↑ V0 Unknown V0 Blue V0 Blue V0 Blue V0 Unknown V0 Blue V0 Unknown V0 Blue V0 Unknown V0 Pink/Magenta V0 Blue V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0",
   "binary_seq": "00000000000000000000000011111000000000000000000000000000000100111111011000010100011001111100001000010000110010001000111111111110000011110100000000000",
   "v_threshold": 0.526,
   "events": [
@@ -443,7 +443,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 33,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e000_000500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e000_000500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 1,
@@ -455,7 +463,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 36,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e001_001500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e001_001500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 2,
@@ -467,7 +483,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 54,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e002_002500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e002_002500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 3,
@@ -479,7 +503,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 49,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e003_003500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e003_003500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 4,
@@ -491,7 +522,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 70,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e004_004500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e004_004500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 5,
@@ -503,7 +541,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 49,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e005_005500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e005_005500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 6,
@@ -515,7 +561,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 54,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e006_006500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e006_006500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 7,
@@ -527,7 +580,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 29,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e007_007500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e007_007500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 8,
@@ -539,7 +599,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 29,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e008_008500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e008_008500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 9,
@@ -551,7 +618,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 31,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e009_009500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e009_009500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 10,
@@ -563,7 +637,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 67,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e010_010500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e010_010500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 11,
@@ -575,7 +656,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 67,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e011_011500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e011_011500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 12,
@@ -587,7 +675,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 70,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e012_012500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e012_012500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 13,
@@ -599,7 +694,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 70,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e013_013500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e013_013500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 14,
@@ -611,7 +714,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 38,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e014_014500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e014_014500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 15,
@@ -623,7 +734,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 38,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e015_015500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e015_015500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 16,
@@ -635,7 +753,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 26,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e016_016500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e016_016500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 17,
@@ -647,7 +773,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e017_017500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e017_017500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 18,
@@ -659,7 +792,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 44,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e018_018500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e018_018500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 19,
@@ -671,7 +811,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 54,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e019_019500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e019_019500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 20,
@@ -683,7 +830,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 67,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e020_020500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e020_020500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 21,
@@ -695,7 +849,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 67,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e021_021500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e021_021500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 22,
@@ -707,7 +868,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 18,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e022_022500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e022_022500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 23,
@@ -719,7 +887,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 18,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e023_023500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e023_023500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 24,
@@ -731,7 +906,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e024_024500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e024_024500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 25,
@@ -743,7 +925,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e025_025500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e025_025500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 26,
@@ -755,7 +944,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e026_026500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e026_026500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 27,
@@ -767,7 +963,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e027_027500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e027_027500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 28,
@@ -779,7 +982,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e028_028500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e028_028500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 29,
@@ -791,7 +1001,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e029_029500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e029_029500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 30,
@@ -803,7 +1021,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e030_030500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e030_030500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 31,
@@ -815,7 +1041,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e031_031500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e031_031500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 32,
@@ -827,7 +1061,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e032_032500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e032_032500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 33,
@@ -839,7 +1081,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e033_033500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e033_033500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 34,
@@ -851,7 +1101,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e034_034500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e034_034500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 35,
@@ -863,7 +1121,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e035_035500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e035_035500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 36,
@@ -875,7 +1141,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e036_036500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e036_036500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 37,
@@ -887,7 +1161,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e037_037500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e037_037500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 38,
@@ -899,7 +1181,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e038_038500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e038_038500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 39,
@@ -911,7 +1201,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e039_039500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e039_039500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 40,
@@ -923,7 +1221,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e040_040500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e040_040500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 41,
@@ -935,7 +1241,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e041_041500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e041_041500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 42,
@@ -947,7 +1260,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e042_042500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e042_042500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 43,
@@ -959,7 +1280,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e043_043500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e043_043500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 44,
@@ -971,7 +1300,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e044_044500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e044_044500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 45,
@@ -983,7 +1320,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e045_045500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e045_045500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 46,
@@ -995,7 +1340,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e046_046500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e046_046500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 47,
@@ -1007,7 +1360,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e047_047500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e047_047500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 48,
@@ -1019,7 +1380,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 34,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e048_048500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e048_048500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 49,
@@ -1031,7 +1400,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e049_049500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e049_049500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 50,
@@ -1043,7 +1420,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 34,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e050_050500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e050_050500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 51,
@@ -1055,7 +1439,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e051_051500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e051_051500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 52,
@@ -1067,7 +1459,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e052_052500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e052_052500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 53,
@@ -1079,7 +1479,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e053_053500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e053_053500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 54,
@@ -1091,7 +1499,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e054_054500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e054_054500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 55,
@@ -1103,7 +1519,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e055_055500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e055_055500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 56,
@@ -1115,7 +1538,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e056_056500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e056_056500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 57,
@@ -1127,7 +1557,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e057_057500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e057_057500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 58,
@@ -1139,7 +1576,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e058_058500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e058_058500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 59,
@@ -1151,7 +1595,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e059_059500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e059_059500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 60,
@@ -1163,7 +1614,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e060_060500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e060_060500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 61,
@@ -1175,7 +1633,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e061_061500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e061_061500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 62,
@@ -1187,7 +1653,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 50,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e062_062500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e062_062500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 63,
@@ -1199,7 +1673,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 1,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e063_063500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e063_063500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 64,
@@ -1211,7 +1692,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 1,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e064_064500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e064_064500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 65,
@@ -1223,7 +1711,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 61,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e065_065500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e065_065500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 66,
@@ -1235,7 +1731,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 50,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e066_066500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e066_066500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 67,
@@ -1247,7 +1751,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 68,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e067_067500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e067_067500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 68,
@@ -1259,7 +1771,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 53,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e068_068500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e068_068500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 69,
@@ -1271,7 +1791,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 41,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e069_069500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e069_069500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 70,
@@ -1283,7 +1811,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 2,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e070_070500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e070_070500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 71,
@@ -1295,7 +1831,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e071_071500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e071_071500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 72,
@@ -1307,7 +1851,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 66,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e072_072500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e072_072500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 73,
@@ -1319,7 +1871,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 45,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e073_073500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e073_073500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 74,
@@ -1331,7 +1891,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 56,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e074_074500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e074_074500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 75,
@@ -1343,7 +1911,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 68,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e075_075500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e075_075500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 76,
@@ -1355,7 +1931,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 58,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e076_076500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e076_076500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 77,
@@ -1367,7 +1951,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 50,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e077_077500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e077_077500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 78,
@@ -1379,7 +1971,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 61,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e078_078500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e078_078500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 79,
@@ -1391,7 +1990,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 69,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e079_079500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e079_079500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 80,
@@ -1403,7 +2009,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 58,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e080_080500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e080_080500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 81,
@@ -1415,7 +2029,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 61,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e081_081500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e081_081500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 82,
@@ -1427,7 +2048,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 42,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e082_082500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e082_082500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 83,
@@ -1439,7 +2068,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 68,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e083_083500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e083_083500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 84,
@@ -1451,7 +2087,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 56,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e084_084500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e084_084500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 85,
@@ -1463,7 +2107,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 65,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e085_085500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e085_085500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 86,
@@ -1475,7 +2127,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 41,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e086_086500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e086_086500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 87,
@@ -1487,7 +2147,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 24,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e087_087500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e087_087500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 88,
@@ -1499,7 +2167,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 24,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e088_088500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e088_088500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 89,
@@ -1511,7 +2187,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 69,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e089_089500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e089_089500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 90,
@@ -1523,7 +2207,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 29,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e090_090500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e090_090500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 91,
@@ -1535,7 +2227,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 64,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e091_091500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e091_091500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 92,
@@ -1547,7 +2246,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 64,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e092_092500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e092_092500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 93,
@@ -1559,7 +2265,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 67,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e093_093500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e093_093500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 94,
@@ -1571,7 +2284,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 1,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e094_094500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e094_094500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 95,
@@ -1583,7 +2303,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e095_095500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e095_095500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 96,
@@ -1595,7 +2323,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e096_096500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e096_096500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 97,
@@ -1607,7 +2343,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e097_097500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e097_097500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 98,
@@ -1619,7 +2363,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 70,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e098_098500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e098_098500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 99,
@@ -1631,7 +2382,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 53,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e099_099500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e099_099500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 100,
@@ -1643,7 +2402,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 61,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e100_100500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e100_100500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 101,
@@ -1655,7 +2422,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 61,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e101_101500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e101_101500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 102,
@@ -1667,7 +2442,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e102_102500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e102_102500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 103,
@@ -1679,7 +2461,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 23,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e103_103500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e103_103500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 104,
@@ -1691,7 +2480,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e104_104500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e104_104500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 105,
@@ -1703,7 +2499,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e105_105500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e105_105500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 106,
@@ -1715,7 +2518,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 68,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e106_106500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e106_106500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 107,
@@ -1727,7 +2538,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 24,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e107_107500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e107_107500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 108,
@@ -1739,7 +2557,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 66,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e108_108500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e108_108500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 109,
@@ -1751,7 +2577,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 41,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e109_109500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e109_109500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 110,
@@ -1763,7 +2597,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 1,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e110_110500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e110_110500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 111,
@@ -1775,7 +2617,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 50,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e111_111500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e111_111500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 112,
@@ -1787,7 +2637,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 65,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e112_112500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e112_112500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 113,
@@ -1799,7 +2657,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 9,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e113_113500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e113_113500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 114,
@@ -1811,7 +2676,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e114_114500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e114_114500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 115,
@@ -1823,7 +2696,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 24,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e115_115500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e115_115500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 116,
@@ -1835,7 +2716,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 49,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e116_116500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e116_116500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 117,
@@ -1847,7 +2735,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 34,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e117_117500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e117_117500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 118,
@@ -1859,7 +2754,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e118_118500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e118_118500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 119,
@@ -1871,7 +2773,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e119_119500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e119_119500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 120,
@@ -1883,7 +2792,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e120_120500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e120_120500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 121,
@@ -1895,7 +2811,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e121_121500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e121_121500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 122,
@@ -1907,7 +2830,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e122_122500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e122_122500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 123,
@@ -1919,7 +2849,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e123_123500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e123_123500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 124,
@@ -1931,7 +2868,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e124_124500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e124_124500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 125,
@@ -1943,7 +2887,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e125_125500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e125_125500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 126,
@@ -1955,7 +2906,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e126_126500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e126_126500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 127,
@@ -1967,7 +2925,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 53,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e127_127500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e127_127500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 128,
@@ -1979,7 +2944,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 69,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e128_128500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e128_128500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 129,
@@ -1991,7 +2964,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 53,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e129_129500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e129_129500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 130,
@@ -2003,7 +2983,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e130_130500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e130_130500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 131,
@@ -2015,7 +3002,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 42,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e131_131500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e131_131500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 132,
@@ -2027,7 +3022,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e132_132500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e132_132500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 133,
@@ -2039,7 +3041,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e133_133500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e133_133500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 134,
@@ -2051,7 +3060,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e134_134500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e134_134500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 135,
@@ -2063,7 +3079,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e135_135500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e135_135500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 136,
@@ -2075,7 +3098,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 50,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e136_136500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e136_136500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 137,
@@ -2087,7 +3117,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 34,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e137_137500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e137_137500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 138,
@@ -2099,7 +3136,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 49,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e138_138500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e138_138500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 139,
@@ -2111,7 +3155,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e139_139500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e139_139500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 140,
@@ -2123,7 +3174,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 49,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e140_140500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e140_140500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 141,
@@ -2135,7 +3193,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 54,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e141_141500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e141_141500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 142,
@@ -2147,7 +3212,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e142_142500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e142_142500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 143,
@@ -2159,7 +3231,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 70,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e143_143500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e143_143500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 144,
@@ -2171,7 +3250,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 38,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e144_144500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e144_144500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 145,
@@ -2183,7 +3269,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 29,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e145_145500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e145_145500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 146,
@@ -2195,7 +3288,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 67,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e146_146500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e146_146500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 147,
@@ -2207,7 +3307,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e147_147500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e147_147500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 148,
@@ -2219,11 +3326,18 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e148_148500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ht9mnog65nf61i3sl0_e148_148500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     }
   ],
   "cycles": [
-    "Unknown↓ Blue↑ Pink/Magenta↓ Unknown Pink/Magenta Blue↑ Pink/Magenta Pink/Magenta Pink/Magenta Pink/Magenta Pink/Magenta Pink/Magenta Pink/Magenta Pink/Magenta↓ Pink/Magenta↓ Pink/Magenta Pink/Magenta↓ Pink/Magenta Pink/Magenta Pink/Magenta Pink/Magenta Pink/Magenta Blue Blue Blue Blue Blue Blue Blue Blue↑ Blue↑ Blue↑ Blue↑ Blue↑ Blue↑ Blue↑ Blue↑ Blue↑ Blue↑ Blue↑ Blue↑ Blue Blue↑ Blue↑ Blue↑ Blue↑ Blue↑ Blue↑ Blue↑ Blue↑ Blue Blue↑ Blue↑ Blue↑ Blue↑ Blue Blue Blue Blue Blue Blue Unknown↑ Unknown↑ Green Green Green↑ Unknown↑ Unknown↑ Unknown↑ Green↑ Blue↑ Unknown↑ Green↑ Green↑ Green↑ Unknown↑ Unknown↑ Unknown↑ Unknown Green Unknown↑ Green Unknown↑ Unknown Green↑ Green↑ Green↑ Green↑ Green↑ Green↑ Pink/Magenta↓ Unknown Unknown Pink/Magenta Green Unknown↑ Unknown↑ Blue↑ Pink/Magenta Unknown↑ Unknown↑ Unknown↑ Blue Blue Blue Blue Unknown↑ Green Green↑ Green↑ Green↑ Unknown↑ Green↑ Unknown Unknown↑ Green↑ Unknown Blue Blue Blue Blue Blue Blue Blue Blue Blue Blue Unknown Green↑ Unknown Blue Unknown↑ Unknown Blue Blue Blue Unknown Blue Unknown Blue Unknown Pink/Magenta Blue Pink/Magenta Pink/Magenta Pink/Magenta Pink/Magenta Pink/Magenta Pink/Magenta"
+    "Unknown↓ V0 Blue↑ V0 Pink/Magenta↓ V0 Unknown V0 Pink/Magenta V0 Blue↑ V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta↓ V0 Pink/Magenta↓ V0 Pink/Magenta V0 Pink/Magenta↓ V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Unknown↑ V0 Unknown↑ V0 Green V0 Green V0 Green↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Green↑ V0 Blue↑ V0 Unknown↑ V0 Green↑ V0 Green↑ V0 Green↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown V0 Green V0 Unknown↑ V0 Green V0 Unknown↑ V0 Unknown V0 Green↑ V0 Green↑ V0 Green↑ V0 Green↑ V0 Green↑ V0 Green↑ V0 Pink/Magenta↓ V0 Unknown V0 Unknown V0 Pink/Magenta V0 Green V0 Unknown↑ V0 Unknown↑ V0 Blue↑ V0 Pink/Magenta V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Blue V0 Blue V0 Blue V0 Blue V0 Unknown↑ V0 Green V0 Green↑ V0 Green↑ V0 Green↑ V0 Unknown↑ V0 Green↑ V0 Unknown V0 Unknown↑ V0 Green↑ V0 Unknown V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Unknown V0 Green↑ V0 Unknown V0 Blue V0 Unknown↑ V0 Unknown V0 Blue V0 Blue V0 Blue V0 Unknown V0 Blue V0 Unknown V0 Blue V0 Unknown V0 Pink/Magenta V0 Blue V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0"
   ],
   "clustering": {
     "eps": 0.34,

--- a/public/sequences_merge/v15044gf0000d2ie6rfog65qka6atq7g.json.sequence.json
+++ b/public/sequences_merge/v15044gf0000d2ie6rfog65qka6atq7g.json.sequence.json
@@ -327,7 +327,7 @@
     }
   },
   "symbol_seq": "MGCZZGRGJAHTTAAASAHAHFBAGAGNNAAAAAUAFTAATSTJJGZZXZZZKAAAAAHABJJSSVAGAKAIAGUACACZAKVAAAIAAAKAHZZZAGTMAIAABJAKJTVASAHAAACAAAFCAFASASTGIIAHAHSAITAIACACAAAAAGAAAFAFIVSAXVVVAIMAEACASAIABAGVCJCVCVBCVC",
-  "symbol_seq_enhanced": "Blue Blue↓ Blue↑ Unknown Unknown Blue Yellow Blue Blue Pink/Magenta↑ Pink/Magenta Pink/Magenta↑ Pink/Magenta Unknown Pink/Magenta↑ Pink/Magenta Blue↓ Unknown Blue↑ Pink/Magenta Blue↑ Blue↑ Pink/Magenta Pink/Magenta Green↓ Pink/Magenta Pink/Magenta Pink/Magenta Pink/Magenta Unknown↑ Pink/Magenta↑ Blue↓ Blue↑ Blue↑ Blue↑ Blue↑ Unknown↓ Unknown Unknown Unknown Unknown Pink/Magenta↓ Pink/Magenta Pink/Magenta Pink/Magenta Blue Blue Unknown↓ Unknown↓ Pink/Magenta↑ Pink/Magenta Pink/Magenta↑ Pink/Magenta Pink/Magenta↓ Yellow↑ Pink/Magenta↑ Pink/Magenta↓ Blue↓ Pink/Magenta Pink/Magenta Pink/Magenta↑ Pink/Magenta↑ Pink/Magenta Pink/Magenta↑ Pink/Magenta Blue↑ Blue↑ Blue↑ Pink/Magenta Pink/Magenta↑ Blue Pink/Magenta↑ Blue Pink/Magenta Blue↑ Pink/Magenta↑ Blue↑ Pink/Magenta Pink/Magenta↓ Unknown↑ Pink/Magenta↓ Pink/Magenta Pink/Magenta Pink/Magenta↑ Pink/Magenta↑ Blue Pink/Magenta Unknown↓ Unknown↓ Pink/Magenta Blue↑ Yellow↑ Yellow↑ Unknown Unknown Unknown↓ Pink/Magenta Pink/Magenta Pink/Magenta↑ Pink/Magenta Pink/Magenta Pink/Magenta↑ Pink/Magenta Pink/Magenta↓ Pink/Magenta Pink/Magenta↓ Pink/Magenta↓ Yellow↓ Pink/Magenta↑ Unknown Unknown↑ Pink/Magenta Pink/Magenta Pink/Magenta Pink/Magenta Blue↓ Blue↑ Pink/Magenta Unknown↓ Pink/Magenta Pink/Magenta Pink/Magenta↑ Pink/Magenta Blue↑ Blue Blue Pink/Magenta Blue Pink/Magenta Blue Blue Pink/Magenta Blue",
+  "symbol_seq_enhanced": "Blue V0 Blue↓ V0 Blue↑ V0 Unknown V0 Unknown V0 Blue V0 Yellow V0 Blue V0 Blue V0 Pink/Magenta↑ V0 Pink/Magenta V0 Pink/Magenta↑ V0 Pink/Magenta V0 Unknown V0 Pink/Magenta↑ V0 Pink/Magenta V0 Blue↓ V0 Unknown V0 Blue↑ V0 Pink/Magenta V0 Blue↑ V0 Blue↑ V0 Pink/Magenta V0 Pink/Magenta V0 Green↓ V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Unknown↑ V0 Pink/Magenta↑ V0 Blue↓ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Unknown↓ V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Pink/Magenta↓ V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Blue V0 Blue V0 Unknown↓ V0 Unknown↓ V0 Pink/Magenta↑ V0 Pink/Magenta V0 Pink/Magenta↑ V0 Pink/Magenta V0 Pink/Magenta↓ V0 Yellow↑ V0 Pink/Magenta↑ V0 Pink/Magenta↓ V0 Blue↓ V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta↑ V0 Pink/Magenta↑ V0 Pink/Magenta V0 Pink/Magenta↑ V0 Pink/Magenta V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Pink/Magenta V0 Pink/Magenta↑ V0 Blue V0 Pink/Magenta↑ V0 Blue V0 Pink/Magenta V0 Blue↑ V0 Pink/Magenta↑ V0 Blue↑ V0 Pink/Magenta V0 Pink/Magenta↓ V0 Unknown↑ V0 Pink/Magenta↓ V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta↑ V0 Pink/Magenta↑ V0 Blue V0 Pink/Magenta V0 Unknown↓ V0 Unknown↓ V0 Pink/Magenta V0 Blue↑ V0 Yellow↑ V0 Yellow↑ V0 Unknown V0 Unknown V0 Unknown↓ V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta↑ V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta↑ V0 Pink/Magenta V0 Pink/Magenta↓ V0 Pink/Magenta V0 Pink/Magenta↓ V0 Pink/Magenta↓ V0 Yellow↓ V0 Pink/Magenta↑ V0 Unknown V0 Unknown↑ V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Blue↓ V0 Blue↑ V0 Pink/Magenta V0 Unknown↓ V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta↑ V0 Pink/Magenta V0 Blue↑ V0 Blue V0 Blue V0 Pink/Magenta V0 Blue V0 Pink/Magenta V0 Blue V0 Blue V0 Pink/Magenta V0 Blue V0",
   "binary_seq": "0010000000000000000000000001000000110011100100011010000000000011000000110000000000000000010111110011111010000100010000100000010101101",
   "v_threshold": 0.534,
   "events": [
@@ -341,7 +341,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e000_000500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e000_000500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 1,
@@ -353,7 +360,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e001_001500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e001_001500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 2,
@@ -365,7 +380,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e002_002500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e002_002500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 3,
@@ -377,7 +400,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 49,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e003_003500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e003_003500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 4,
@@ -389,7 +419,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 49,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e004_004500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e004_004500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 5,
@@ -401,7 +438,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e005_005500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e005_005500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 6,
@@ -413,7 +457,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e006_006500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e006_006500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 7,
@@ -425,7 +476,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e007_007500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e007_007500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 8,
@@ -437,7 +495,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e008_008500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e008_008500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 9,
@@ -449,7 +514,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 31,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e009_009500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e009_009500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 10,
@@ -461,7 +534,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e010_010500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e010_010500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 11,
@@ -473,7 +553,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e011_011500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e011_011500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 12,
@@ -485,7 +573,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 70,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e012_012500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e012_012500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 13,
@@ -497,7 +592,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 64,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e013_013500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e013_013500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 14,
@@ -509,7 +611,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 31,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e014_014500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e014_014500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 15,
@@ -521,7 +631,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 31,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e015_015500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e015_015500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 16,
@@ -533,7 +650,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e016_016500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e016_016500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 17,
@@ -545,7 +670,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 61,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e017_017500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e017_017500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 18,
@@ -557,7 +689,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e018_018500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e018_018500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 19,
@@ -569,7 +709,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 26,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e019_019500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e019_019500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 20,
@@ -581,7 +728,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e020_020500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e020_020500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 21,
@@ -593,7 +748,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e021_021500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e021_021500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 22,
@@ -605,7 +768,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 70,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e022_022500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e022_022500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 23,
@@ -617,7 +787,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 70,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e023_023500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e023_023500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 24,
@@ -629,7 +806,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 56,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e024_024500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e024_024500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 25,
@@ -641,7 +826,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 54,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e025_025500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e025_025500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 26,
@@ -653,7 +845,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e026_026500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e026_026500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 27,
@@ -665,7 +864,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 70,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e027_027500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e027_027500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 28,
@@ -677,7 +883,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e028_028500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e028_028500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 29,
@@ -689,7 +902,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e029_029500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e029_029500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 30,
@@ -701,7 +922,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e030_030500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e030_030500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 31,
@@ -713,7 +942,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e031_031500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e031_031500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 32,
@@ -725,7 +962,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e032_032500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e032_032500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 33,
@@ -737,7 +982,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e033_033500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e033_033500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 34,
@@ -749,7 +1002,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 49,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e034_034500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e034_034500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 35,
@@ -761,7 +1022,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 49,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e035_035500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e035_035500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 36,
@@ -773,7 +1042,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 2,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e036_036500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e036_036500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 37,
@@ -785,7 +1062,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 49,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e037_037500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e037_037500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 38,
@@ -797,7 +1081,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 49,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e038_038500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e038_038500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 39,
@@ -809,7 +1100,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 49,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e039_039500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e039_039500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 40,
@@ -821,7 +1119,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e040_040500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e040_040500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 41,
@@ -833,7 +1138,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 70,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e041_041500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e041_041500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 42,
@@ -845,7 +1158,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 70,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e042_042500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e042_042500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 43,
@@ -857,7 +1177,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 31,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e043_043500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e043_043500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 44,
@@ -869,7 +1196,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 44,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e044_044500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e044_044500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 45,
@@ -881,7 +1215,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e045_045500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e045_045500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 46,
@@ -893,7 +1234,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e046_046500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e046_046500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 47,
@@ -905,7 +1253,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e047_047500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e047_047500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 48,
@@ -917,7 +1273,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e048_048500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e048_048500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 49,
@@ -929,7 +1293,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e049_049500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e049_049500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 50,
@@ -941,7 +1313,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 26,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e050_050500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e050_050500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 51,
@@ -953,7 +1332,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 29,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e051_051500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e051_051500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 52,
@@ -965,7 +1352,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 67,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e052_052500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e052_052500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 53,
@@ -977,7 +1371,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 26,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e053_053500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e053_053500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 54,
@@ -989,7 +1391,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e054_054500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e054_054500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 55,
@@ -1001,7 +1411,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 38,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e055_055500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e055_055500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 56,
@@ -1013,7 +1431,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 38,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e056_056500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e056_056500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 57,
@@ -1025,7 +1451,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 49,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e057_057500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e057_057500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 58,
@@ -1037,7 +1471,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 29,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e058_058500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e058_058500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 59,
@@ -1049,7 +1490,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e059_059500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e059_059500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 60,
@@ -1061,7 +1509,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 70,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e060_060500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e060_060500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 61,
@@ -1073,7 +1529,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 67,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e061_061500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e061_061500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 62,
@@ -1085,7 +1549,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 70,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e062_062500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e062_062500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 63,
@@ -1097,7 +1568,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 29,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e063_063500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e063_063500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 64,
@@ -1109,7 +1588,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 31,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e064_064500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e064_064500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 65,
@@ -1121,7 +1607,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 49,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e065_065500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e065_065500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 66,
@@ -1133,7 +1627,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 49,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e066_066500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e066_066500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 67,
@@ -1145,7 +1647,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 49,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e067_067500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e067_067500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 68,
@@ -1157,7 +1667,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 26,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e068_068500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e068_068500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 69,
@@ -1169,7 +1686,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e069_069500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e069_069500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 70,
@@ -1181,7 +1706,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e070_070500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e070_070500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 71,
@@ -1193,7 +1725,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 67,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e071_071500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e071_071500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 72,
@@ -1205,7 +1745,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e072_072500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e072_072500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 73,
@@ -1217,7 +1764,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 44,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e073_073500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e073_073500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 74,
@@ -1229,7 +1783,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e074_074500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e074_074500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 75,
@@ -1241,7 +1803,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 29,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e075_075500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e075_075500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 76,
@@ -1253,7 +1823,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e076_076500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e076_076500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 77,
@@ -1265,7 +1843,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e077_077500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e077_077500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 78,
@@ -1277,7 +1862,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e078_078500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e078_078500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 79,
@@ -1289,7 +1882,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 64,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e079_079500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e079_079500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 80,
@@ -1301,7 +1902,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 31,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e080_080500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e080_080500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 81,
@@ -1313,7 +1922,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 70,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e081_081500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e081_081500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 82,
@@ -1325,7 +1941,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 38,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e082_082500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e082_082500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 83,
@@ -1337,7 +1960,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 70,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e083_083500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e083_083500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 84,
@@ -1349,7 +1980,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 54,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e084_084500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e084_084500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 85,
@@ -1361,7 +2000,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e085_085500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e085_085500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 86,
@@ -1373,7 +2019,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 54,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e086_086500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e086_086500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 87,
@@ -1385,7 +2038,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 64,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e087_087500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e087_087500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 88,
@@ -1397,7 +2058,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 64,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e088_088500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e088_088500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 89,
@@ -1409,7 +2078,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e089_089500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e089_089500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 90,
@@ -1421,7 +2097,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e090_090500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e090_090500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 91,
@@ -1433,7 +2117,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e091_091500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e091_091500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 92,
@@ -1445,7 +2137,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e092_092500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e092_092500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 93,
@@ -1457,7 +2157,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 31,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e093_093500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e093_093500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 94,
@@ -1469,7 +2176,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 31,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e094_094500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e094_094500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 95,
@@ -1481,7 +2195,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e095_095500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e095_095500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 96,
@@ -1493,7 +2215,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 67,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e096_096500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e096_096500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 97,
@@ -1505,7 +2234,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e097_097500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e097_097500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 98,
@@ -1517,7 +2253,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 67,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e098_098500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e098_098500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 99,
@@ -1529,7 +2273,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 38,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e099_099500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e099_099500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 100,
@@ -1541,7 +2292,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 38,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e100_100500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e100_100500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 101,
@@ -1553,7 +2311,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 70,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e101_101500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e101_101500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 102,
@@ -1565,7 +2331,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 70,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e102_102500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e102_102500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 103,
@@ -1577,7 +2350,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 26,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e103_103500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e103_103500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 104,
@@ -1589,7 +2370,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 70,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e104_104500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e104_104500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 105,
@@ -1601,7 +2389,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 54,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e105_105500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e105_105500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 106,
@@ -1613,7 +2409,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 54,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e106_106500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e106_106500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 107,
@@ -1625,7 +2429,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e107_107500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e107_107500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 108,
@@ -1637,7 +2449,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e108_108500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e108_108500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 109,
@@ -1649,7 +2469,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e109_109500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e109_109500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 110,
@@ -1661,7 +2488,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 50,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e110_110500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e110_110500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 111,
@@ -1673,7 +2508,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e111_111500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e111_111500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 112,
@@ -1685,7 +2527,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e112_112500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e112_112500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 113,
@@ -1697,7 +2546,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e113_113500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e113_113500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 114,
@@ -1709,7 +2565,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 67,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e114_114500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e114_114500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 115,
@@ -1721,7 +2584,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e115_115500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e115_115500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 116,
@@ -1733,7 +2604,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 34,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e116_116500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e116_116500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 117,
@@ -1745,7 +2624,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 38,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e117_117500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e117_117500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 118,
@@ -1757,7 +2643,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 64,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e118_118500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e118_118500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 119,
@@ -1769,7 +2663,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 67,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e119_119500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e119_119500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 120,
@@ -1781,7 +2682,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 44,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e120_120500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e120_120500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 121,
@@ -1793,7 +2701,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 26,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e121_121500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e121_121500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 122,
@@ -1805,7 +2721,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e122_122500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e122_122500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 123,
@@ -1817,7 +2740,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e123_123500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e123_123500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 124,
@@ -1829,7 +2760,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e124_124500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e124_124500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 125,
@@ -1841,7 +2779,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e125_125500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e125_125500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 126,
@@ -1853,7 +2798,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e126_126500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e126_126500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 127,
@@ -1865,7 +2817,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e127_127500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e127_127500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 128,
@@ -1877,7 +2836,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e128_128500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e128_128500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 129,
@@ -1889,7 +2855,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e129_129500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e129_129500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 130,
@@ -1901,7 +2874,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e130_130500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e130_130500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 131,
@@ -1913,7 +2893,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e131_131500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e131_131500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 132,
@@ -1925,11 +2912,18 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e132_132500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2ie6rfog65qka6atq7g_e132_132500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     }
   ],
   "cycles": [
-    "Blue Blue↓ Blue↑ Unknown Unknown Blue Yellow Blue Blue Pink/Magenta↑ Pink/Magenta Pink/Magenta↑ Pink/Magenta Unknown Pink/Magenta↑ Pink/Magenta Blue↓ Unknown Blue↑ Pink/Magenta Blue↑ Blue↑ Pink/Magenta Pink/Magenta Green↓ Pink/Magenta Pink/Magenta Pink/Magenta Pink/Magenta Unknown↑ Pink/Magenta↑ Blue↓ Blue↑ Blue↑ Blue↑ Blue↑ Unknown↓ Unknown Unknown Unknown Unknown Pink/Magenta↓ Pink/Magenta Pink/Magenta Pink/Magenta Blue Blue Unknown↓ Unknown↓ Pink/Magenta↑ Pink/Magenta Pink/Magenta↑ Pink/Magenta Pink/Magenta↓ Yellow↑ Pink/Magenta↑ Pink/Magenta↓ Blue↓ Pink/Magenta Pink/Magenta Pink/Magenta↑ Pink/Magenta↑ Pink/Magenta Pink/Magenta↑ Pink/Magenta Blue↑ Blue↑ Blue↑ Pink/Magenta Pink/Magenta↑ Blue Pink/Magenta↑ Blue Pink/Magenta Blue↑ Pink/Magenta↑ Blue↑ Pink/Magenta Pink/Magenta↓ Unknown↑ Pink/Magenta↓ Pink/Magenta Pink/Magenta Pink/Magenta↑ Pink/Magenta↑ Blue Pink/Magenta Unknown↓ Unknown↓ Pink/Magenta Blue↑ Yellow↑ Yellow↑ Unknown Unknown Unknown↓ Pink/Magenta Pink/Magenta Pink/Magenta↑ Pink/Magenta Pink/Magenta Pink/Magenta↑ Pink/Magenta Pink/Magenta↓ Pink/Magenta Pink/Magenta↓ Pink/Magenta↓ Yellow↓ Pink/Magenta↑ Unknown Unknown↑ Pink/Magenta Pink/Magenta Pink/Magenta Pink/Magenta Blue↓ Blue↑ Pink/Magenta Unknown↓ Pink/Magenta Pink/Magenta Pink/Magenta↑ Pink/Magenta Blue↑ Blue Blue Pink/Magenta Blue Pink/Magenta Blue Blue Pink/Magenta Blue"
+    "Blue V0 Blue↓ V0 Blue↑ V0 Unknown V0 Unknown V0 Blue V0 Yellow V0 Blue V0 Blue V0 Pink/Magenta↑ V0 Pink/Magenta V0 Pink/Magenta↑ V0 Pink/Magenta V0 Unknown V0 Pink/Magenta↑ V0 Pink/Magenta V0 Blue↓ V0 Unknown V0 Blue↑ V0 Pink/Magenta V0 Blue↑ V0 Blue↑ V0 Pink/Magenta V0 Pink/Magenta V0 Green↓ V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Unknown↑ V0 Pink/Magenta↑ V0 Blue↓ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Unknown↓ V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Pink/Magenta↓ V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Blue V0 Blue V0 Unknown↓ V0 Unknown↓ V0 Pink/Magenta↑ V0 Pink/Magenta V0 Pink/Magenta↑ V0 Pink/Magenta V0 Pink/Magenta↓ V0 Yellow↑ V0 Pink/Magenta↑ V0 Pink/Magenta↓ V0 Blue↓ V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta↑ V0 Pink/Magenta↑ V0 Pink/Magenta V0 Pink/Magenta↑ V0 Pink/Magenta V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Pink/Magenta V0 Pink/Magenta↑ V0 Blue V0 Pink/Magenta↑ V0 Blue V0 Pink/Magenta V0 Blue↑ V0 Pink/Magenta↑ V0 Blue↑ V0 Pink/Magenta V0 Pink/Magenta↓ V0 Unknown↑ V0 Pink/Magenta↓ V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta↑ V0 Pink/Magenta↑ V0 Blue V0 Pink/Magenta V0 Unknown↓ V0 Unknown↓ V0 Pink/Magenta V0 Blue↑ V0 Yellow↑ V0 Yellow↑ V0 Unknown V0 Unknown V0 Unknown↓ V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta↑ V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta↑ V0 Pink/Magenta V0 Pink/Magenta↓ V0 Pink/Magenta V0 Pink/Magenta↓ V0 Pink/Magenta↓ V0 Yellow↓ V0 Pink/Magenta↑ V0 Unknown V0 Unknown↑ V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Blue↓ V0 Blue↑ V0 Pink/Magenta V0 Unknown↓ V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta↑ V0 Pink/Magenta V0 Blue↑ V0 Blue V0 Blue V0 Pink/Magenta V0 Blue V0 Pink/Magenta V0 Blue V0 Blue V0 Pink/Magenta V0 Blue V0"
   ],
   "clustering": {
     "eps": 0.34,

--- a/public/sequences_merge/v15044gf0000d2iiaufog65l626ia17g.json.sequence.json
+++ b/public/sequences_merge/v15044gf0000d2iiaufog65l626ia17g.json.sequence.json
@@ -378,7 +378,7 @@
     }
   },
   "symbol_seq": "NOOAEIP_WLEEEKIIEIIWEHAVHLLAIIRGLQEEEIHEEEHIREKLKAPKIHKHLLLHQKLKLEEEHLLEKIHEIIIIILKEKUHQKRHEHKIEIEKEEEISSFDSSOFDDCGEPHADUANUURADBBUUADAMUUALAJPPADUPAPWHAIPPADILE",
-  "symbol_seq_enhanced": "Blue Blue Blue Blue Unknown Yellow↓ Yellow Unknown↑ Yellow Unknown↑ Unknown Unknown Unknown Unknown Yellow↓ Yellow Unknown↓ Yellow Yellow↓ Yellow Unknown↑ Yellow↓ Unknown↓ Yellow Unknown Unknown Pink/Magenta↓ Yellow Yellow↑ Blue↓ Unknown↓ Unknown↓ Unknown↑ Unknown Unknown Yellow Unknown↓ Unknown Unknown↓ Unknown↓ Yellow↓ Yellow Yellow↓ Unknown Unknown↑ Unknown↓ Unknown Unknown Unknown Yellow↓ Yellow↓ Unknown↓ Yellow↓ Unknown Unknown↓ Unknown↓ Yellow Unknown Unknown↑ Unknown↓ Unknown Unknown Unknown Unknown Unknown↓ Yellow↓ Unknown↑ Unknown Unknown↓ Unknown Yellow Yellow Unknown↓ Yellow↓ Yellow Yellow Yellow↑ Yellow↑ Unknown↓ Unknown↑ Unknown↓ Unknown↓ Yellow↓ Yellow↓ Unknown↑ Unknown Yellow Unknown Unknown Unknown Unknown Yellow↓ Unknown Yellow↑ Unknown↑ Unknown↑ Unknown↑ Unknown↑ Unknown↑ Yellow↓ Pink/Magenta Pink/Magenta Blue Blue Unknown Unknown Blue Blue Blue Blue Blue Blue Unknown↑ Yellow↑ Yellow↑ Yellow Yellow Unknown Yellow Yellow Yellow Yellow↑ Green Yellow↑ Yellow Unknown↑ Unknown Yellow Yellow Green↑ Unknown Yellow↑ Yellow↑ Yellow Yellow↑ Yellow↑ Unknown↓ Yellow Unknown↑ Blue↓ Yellow Yellow Yellow Yellow↑ Yellow↓ Unknown Unknown",
+  "symbol_seq_enhanced": "Blue V0 Blue V0 Blue V0 Blue V0 Unknown V0 Yellow↓ V0 Yellow V0 Unknown↑ V0 Yellow V0 Unknown↑ V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Yellow↓ V0 Yellow V0 Unknown↓ V0 Yellow V0 Yellow↓ V0 Yellow V0 Unknown↑ V0 Yellow↓ V0 Unknown↓ V0 Yellow V0 Unknown V0 Unknown V0 Pink/Magenta↓ V0 Yellow V0 Yellow↑ V0 Blue↓ V0 Unknown↓ V0 Unknown↓ V0 Unknown↑ V0 Unknown V0 Unknown V0 Yellow V0 Unknown↓ V0 Unknown V0 Unknown↓ V0 Unknown↓ V0 Yellow↓ V0 Yellow V0 Yellow↓ V0 Unknown V0 Unknown↑ V0 Unknown↓ V0 Unknown V0 Unknown V0 Unknown V0 Yellow↓ V0 Yellow↓ V0 Unknown↓ V0 Yellow↓ V0 Unknown V0 Unknown↓ V0 Unknown↓ V0 Yellow V0 Unknown V0 Unknown↑ V0 Unknown↓ V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Unknown↓ V0 Yellow↓ V0 Unknown↑ V0 Unknown V0 Unknown↓ V0 Unknown V0 Yellow V0 Yellow V0 Unknown↓ V0 Yellow↓ V0 Yellow V0 Yellow V0 Yellow↑ V0 Yellow↑ V0 Unknown↓ V0 Unknown↑ V0 Unknown↓ V0 Unknown↓ V0 Yellow↓ V0 Yellow↓ V0 Unknown↑ V0 Unknown V0 Yellow V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Yellow↓ V0 Unknown V0 Yellow↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Yellow↓ V0 Pink/Magenta V0 Pink/Magenta V0 Blue V0 Blue V0 Unknown V0 Unknown V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Unknown↑ V0 Yellow↑ V0 Yellow↑ V0 Yellow V0 Yellow V0 Unknown V0 Yellow V0 Yellow V0 Yellow V0 Yellow↑ V0 Green V0 Yellow↑ V0 Yellow V0 Unknown↑ V0 Unknown V0 Yellow V0 Yellow V0 Green↑ V0 Unknown V0 Yellow↑ V0 Yellow↑ V0 Yellow V0 Yellow↑ V0 Yellow↑ V0 Unknown↓ V0 Yellow V0 Unknown↑ V0 Blue↓ V0 Yellow V0 Yellow V0 Yellow V0 Yellow↑ V0 Yellow↓ V0 Unknown V0 Unknown V0",
   "binary_seq": "000100000111000110000000001000000011001101000000000110111000111100000000100000110001000000000100000000000010000011000111001000111001001001101000001",
   "v_threshold": 0.564,
   "events": [
@@ -392,7 +392,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e000_000250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e000_000250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 1,
@@ -404,7 +411,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e001_000750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e001_000750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 2,
@@ -416,7 +430,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e002_001250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e002_001250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 3,
@@ -428,7 +449,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e003_001750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e003_001750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 4,
@@ -440,7 +468,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e004_002250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e004_002250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 5,
@@ -452,7 +487,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e005_002750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e005_002750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 6,
@@ -464,7 +507,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e006_003250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e006_003250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 7,
@@ -476,7 +526,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": -2,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e007_003750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e007_003750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 8,
@@ -488,7 +546,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e008_004250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e008_004250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 9,
@@ -500,7 +565,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e009_004750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e009_004750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 10,
@@ -512,7 +585,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e010_005250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e010_005250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 11,
@@ -524,7 +604,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e011_005750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e011_005750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 12,
@@ -536,7 +623,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e012_006250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e012_006250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 13,
@@ -548,7 +642,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e013_006750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e013_006750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 14,
@@ -560,7 +661,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e014_007250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e014_007250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 15,
@@ -572,7 +681,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e015_007750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e015_007750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 16,
@@ -584,7 +700,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e016_008250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e016_008250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 17,
@@ -596,7 +720,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e017_008750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e017_008750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 18,
@@ -608,7 +739,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e018_009250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e018_009250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 19,
@@ -620,7 +759,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e019_009750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e019_009750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 20,
@@ -632,7 +778,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e020_010250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e020_010250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 21,
@@ -644,7 +798,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e021_010750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e021_010750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 22,
@@ -656,7 +818,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 53,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e022_011250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e022_011250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 23,
@@ -668,7 +838,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e023_011750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e023_011750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 24,
@@ -680,7 +857,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e024_012250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e024_012250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 25,
@@ -692,7 +876,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e025_012750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e025_012750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 26,
@@ -704,7 +895,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 67,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e026_013250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e026_013250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 27,
@@ -716,7 +915,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e027_013750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e027_013750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 28,
@@ -728,7 +934,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e028_014250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e028_014250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 29,
@@ -740,7 +954,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e029_014750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e029_014750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 30,
@@ -752,7 +974,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e030_015250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e030_015250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 31,
@@ -764,7 +994,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e031_015750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e031_015750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 32,
@@ -776,7 +1014,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e032_016250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e032_016250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 33,
@@ -788,7 +1034,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e033_016750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e033_016750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 34,
@@ -800,7 +1053,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e034_017250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e034_017250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 35,
@@ -812,7 +1072,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e035_017750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e035_017750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 36,
@@ -824,7 +1091,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e036_018250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e036_018250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 37,
@@ -836,7 +1111,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e037_018750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e037_018750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 38,
@@ -848,7 +1130,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e038_019250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e038_019250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 39,
@@ -860,7 +1150,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e039_019750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e039_019750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 40,
@@ -872,7 +1170,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e040_020250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e040_020250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 41,
@@ -884,7 +1190,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e041_020750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e041_020750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 42,
@@ -896,7 +1209,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e042_021250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e042_021250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 43,
@@ -908,7 +1229,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e043_021750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e043_021750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 44,
@@ -920,7 +1248,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e044_022250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e044_022250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 45,
@@ -932,7 +1268,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e045_022750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e045_022750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 46,
@@ -944,7 +1288,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e046_023250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e046_023250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 47,
@@ -956,7 +1307,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 9,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e047_023750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e047_023750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 48,
@@ -968,7 +1326,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e048_024250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e048_024250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 49,
@@ -980,7 +1345,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e049_024750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e049_024750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 50,
@@ -992,7 +1365,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e050_025250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e050_025250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 51,
@@ -1004,7 +1385,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e051_025750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e051_025750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 52,
@@ -1016,7 +1405,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e052_026250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e052_026250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 53,
@@ -1028,7 +1425,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e053_026750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e053_026750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 54,
@@ -1040,7 +1444,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e054_027250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e054_027250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 55,
@@ -1052,7 +1464,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e055_027750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e055_027750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 56,
@@ -1064,7 +1484,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e056_028250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e056_028250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 57,
@@ -1076,7 +1503,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e057_028750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e057_028750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 58,
@@ -1088,7 +1522,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e058_029250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e058_029250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 59,
@@ -1100,7 +1542,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e059_029750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e059_029750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 60,
@@ -1112,7 +1562,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e060_030250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e060_030250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 61,
@@ -1124,7 +1581,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e061_030750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e061_030750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 62,
@@ -1136,7 +1600,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e062_031250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e062_031250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 63,
@@ -1148,7 +1619,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e063_031750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e063_031750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 64,
@@ -1160,7 +1638,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e064_032250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e064_032250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 65,
@@ -1172,7 +1658,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e065_032750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e065_032750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 66,
@@ -1184,7 +1678,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e066_033250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e066_033250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 67,
@@ -1196,7 +1698,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e067_033750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e067_033750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 68,
@@ -1208,7 +1717,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e068_034250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e068_034250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 69,
@@ -1220,7 +1737,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e069_034750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e069_034750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 70,
@@ -1232,7 +1756,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e070_035250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e070_035250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 71,
@@ -1244,7 +1775,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e071_035750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e071_035750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 72,
@@ -1256,7 +1794,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e072_036250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e072_036250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 73,
@@ -1268,7 +1814,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e073_036750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e073_036750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 74,
@@ -1280,7 +1834,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e074_037250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e074_037250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 75,
@@ -1292,7 +1853,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e075_037750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e075_037750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 76,
@@ -1304,7 +1872,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e076_038250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e076_038250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 77,
@@ -1316,7 +1892,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e077_038750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e077_038750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 78,
@@ -1328,7 +1912,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e078_039250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e078_039250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 79,
@@ -1340,7 +1932,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e079_039750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e079_039750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 80,
@@ -1352,7 +1952,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e080_040250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e080_040250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 81,
@@ -1364,7 +1972,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e081_040750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e081_040750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 82,
@@ -1376,7 +1992,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e082_041250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e082_041250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 83,
@@ -1388,7 +2012,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e083_041750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e083_041750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 84,
@@ -1400,7 +2032,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e084_042250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e084_042250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 85,
@@ -1412,7 +2052,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e085_042750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e085_042750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 86,
@@ -1424,7 +2071,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e086_043250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e086_043250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 87,
@@ -1436,7 +2090,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e087_043750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e087_043750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 88,
@@ -1448,7 +2109,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e088_044250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e088_044250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 89,
@@ -1460,7 +2128,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e089_044750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e089_044750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 90,
@@ -1472,7 +2147,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e090_045250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e090_045250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 91,
@@ -1484,7 +2166,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e091_045750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e091_045750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 92,
@@ -1496,7 +2186,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e092_046250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e092_046250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 93,
@@ -1508,7 +2205,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e093_046750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e093_046750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 94,
@@ -1520,7 +2225,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e094_047250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e094_047250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 95,
@@ -1532,7 +2245,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e095_047750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e095_047750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 96,
@@ -1544,7 +2265,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e096_048250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e096_048250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 97,
@@ -1556,7 +2285,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e097_048750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e097_048750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 98,
@@ -1568,7 +2305,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e098_049250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e098_049250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 99,
@@ -1580,7 +2325,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e099_049750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e099_049750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 100,
@@ -1592,7 +2345,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e100_050250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e100_050250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 101,
@@ -1604,7 +2364,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e101_050750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e101_050750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 102,
@@ -1616,7 +2383,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e102_051250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e102_051250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 103,
@@ -1628,7 +2402,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e103_051750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e103_051750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 104,
@@ -1640,7 +2421,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e104_052250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e104_052250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 105,
@@ -1652,7 +2440,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e105_052750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e105_052750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 106,
@@ -1664,7 +2459,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e106_053250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e106_053250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 107,
@@ -1676,7 +2478,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e107_053750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e107_053750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 108,
@@ -1688,7 +2497,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e108_054250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e108_054250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 109,
@@ -1700,7 +2516,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e109_054750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e109_054750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 110,
@@ -1712,7 +2535,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e110_055250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e110_055250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 111,
@@ -1724,7 +2554,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e111_055750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e111_055750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 112,
@@ -1736,7 +2573,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e112_056250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e112_056250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 113,
@@ -1748,7 +2593,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e113_056750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e113_056750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 114,
@@ -1760,7 +2613,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e114_057250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e114_057250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 115,
@@ -1772,7 +2633,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 5,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e115_057750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e115_057750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 116,
@@ -1784,7 +2652,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e116_058250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e116_058250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 117,
@@ -1796,7 +2671,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 27,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e117_058750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e117_058750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 118,
@@ -1808,7 +2690,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e118_059250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e118_059250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 119,
@@ -1820,7 +2709,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e119_059750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e119_059750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 120,
@@ -1832,7 +2728,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e120_060250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e120_060250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 121,
@@ -1844,7 +2747,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 5,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e121_060750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e121_060750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 122,
@@ -1856,7 +2767,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 66,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e122_061250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e122_061250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 123,
@@ -1868,7 +2786,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e123_061750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e123_061750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 124,
@@ -1880,7 +2806,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e124_062250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e124_062250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 125,
@@ -1892,7 +2825,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 5,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e125_062750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e125_062750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 126,
@@ -1904,7 +2845,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 7,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e126_063250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e126_063250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 127,
@@ -1916,7 +2864,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e127_063750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e127_063750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 128,
@@ -1928,7 +2883,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e128_064250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e128_064250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 129,
@@ -1940,7 +2902,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 1,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e129_064750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e129_064750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 130,
@@ -1952,7 +2922,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 24,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e130_065250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e130_065250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 131,
@@ -1964,7 +2941,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e131_065750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e131_065750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 132,
@@ -1976,7 +2961,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e132_066250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e132_066250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 133,
@@ -1988,7 +2981,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 5,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e133_066750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e133_066750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 134,
@@ -2000,7 +3000,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e134_067250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e134_067250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 135,
@@ -2012,7 +3020,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e135_067750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e135_067750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 136,
@@ -2024,7 +3040,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 9,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e136_068250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e136_068250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 137,
@@ -2036,7 +3060,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e137_068750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e137_068750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 138,
@@ -2048,7 +3079,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e138_069250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e138_069250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 139,
@@ -2060,7 +3099,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e139_069750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e139_069750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 140,
@@ -2072,7 +3119,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e140_070250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e140_070250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 141,
@@ -2084,7 +3138,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e141_070750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e141_070750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 142,
@@ -2096,7 +3157,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e142_071250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e142_071250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 143,
@@ -2108,7 +3176,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 5,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e143_071750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e143_071750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 144,
@@ -2120,7 +3196,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e144_072250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e144_072250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 145,
@@ -2132,7 +3216,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e145_072750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e145_072750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 146,
@@ -2144,11 +3235,18 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e146_073250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iiaufog65l626ia17g_e146_073250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     }
   ],
   "cycles": [
-    "Blue Blue Blue Blue Unknown Yellow↓ Yellow Unknown↑ Yellow Unknown↑ Unknown Unknown Unknown Unknown Yellow↓ Yellow Unknown↓ Yellow Yellow↓ Yellow Unknown↑ Yellow↓ Unknown↓ Yellow Unknown Unknown Pink/Magenta↓ Yellow Yellow↑ Blue↓ Unknown↓ Unknown↓ Unknown↑ Unknown Unknown Yellow Unknown↓ Unknown Unknown↓ Unknown↓ Yellow↓ Yellow Yellow↓ Unknown Unknown↑ Unknown↓ Unknown Unknown Unknown Yellow↓ Yellow↓ Unknown↓ Yellow↓ Unknown Unknown↓ Unknown↓ Yellow Unknown Unknown↑ Unknown↓ Unknown Unknown Unknown Unknown Unknown↓ Yellow↓ Unknown↑ Unknown Unknown↓ Unknown Yellow Yellow Unknown↓ Yellow↓ Yellow Yellow Yellow↑ Yellow↑ Unknown↓ Unknown↑ Unknown↓ Unknown↓ Yellow↓ Yellow↓ Unknown↑ Unknown Yellow Unknown Unknown Unknown Unknown Yellow↓ Unknown Yellow↑ Unknown↑ Unknown↑ Unknown↑ Unknown↑ Unknown↑ Yellow↓ Pink/Magenta Pink/Magenta Blue Blue Unknown Unknown Blue Blue Blue Blue Blue Blue Unknown↑ Yellow↑ Yellow↑ Yellow Yellow Unknown Yellow Yellow Yellow Yellow↑ Green Yellow↑ Yellow Unknown↑ Unknown Yellow Yellow Green↑ Unknown Yellow↑ Yellow↑ Yellow Yellow↑ Yellow↑ Unknown↓ Yellow Unknown↑ Blue↓ Yellow Yellow Yellow Yellow↑ Yellow↓ Unknown Unknown"
+    "Blue V0 Blue V0 Blue V0 Blue V0 Unknown V0 Yellow↓ V0 Yellow V0 Unknown↑ V0 Yellow V0 Unknown↑ V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Yellow↓ V0 Yellow V0 Unknown↓ V0 Yellow V0 Yellow↓ V0 Yellow V0 Unknown↑ V0 Yellow↓ V0 Unknown↓ V0 Yellow V0 Unknown V0 Unknown V0 Pink/Magenta↓ V0 Yellow V0 Yellow↑ V0 Blue↓ V0 Unknown↓ V0 Unknown↓ V0 Unknown↑ V0 Unknown V0 Unknown V0 Yellow V0 Unknown↓ V0 Unknown V0 Unknown↓ V0 Unknown↓ V0 Yellow↓ V0 Yellow V0 Yellow↓ V0 Unknown V0 Unknown↑ V0 Unknown↓ V0 Unknown V0 Unknown V0 Unknown V0 Yellow↓ V0 Yellow↓ V0 Unknown↓ V0 Yellow↓ V0 Unknown V0 Unknown↓ V0 Unknown↓ V0 Yellow V0 Unknown V0 Unknown↑ V0 Unknown↓ V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Unknown↓ V0 Yellow↓ V0 Unknown↑ V0 Unknown V0 Unknown↓ V0 Unknown V0 Yellow V0 Yellow V0 Unknown↓ V0 Yellow↓ V0 Yellow V0 Yellow V0 Yellow↑ V0 Yellow↑ V0 Unknown↓ V0 Unknown↑ V0 Unknown↓ V0 Unknown↓ V0 Yellow↓ V0 Yellow↓ V0 Unknown↑ V0 Unknown V0 Yellow V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Yellow↓ V0 Unknown V0 Yellow↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Yellow↓ V0 Pink/Magenta V0 Pink/Magenta V0 Blue V0 Blue V0 Unknown V0 Unknown V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Unknown↑ V0 Yellow↑ V0 Yellow↑ V0 Yellow V0 Yellow V0 Unknown V0 Yellow V0 Yellow V0 Yellow V0 Yellow↑ V0 Green V0 Yellow↑ V0 Yellow V0 Unknown↑ V0 Unknown V0 Yellow V0 Yellow V0 Green↑ V0 Unknown V0 Yellow↑ V0 Yellow↑ V0 Yellow V0 Yellow↑ V0 Yellow↑ V0 Unknown↓ V0 Yellow V0 Unknown↑ V0 Blue↓ V0 Yellow V0 Yellow V0 Yellow V0 Yellow↑ V0 Yellow↓ V0 Unknown V0 Unknown V0"
   ],
   "clustering": {
     "eps": 0.34,

--- a/public/sequences_merge/v15044gf0000d2iifsnog65r86tlmk0g.json.sequence.json
+++ b/public/sequences_merge/v15044gf0000d2iifsnog65r86tlmk0g.json.sequence.json
@@ -429,7 +429,7 @@
     }
   },
   "symbol_seq": "BBBBAVCZHHBAPBCAQGBGGJCAYCCAKGDCCDCCCABFACNGMABBAFAALALASSABHFQFABMBMVJCAUMAEAAAAAICCJMKDDHTAGCIAUGOGCGAEJJCJJJCJJMEANRCIJBBJJDAHAHOSAMSSNFFFADDFFDDCDBXNONBFC",
-  "symbol_seq_enhanced": "Blue↓ Blue↑ Blue↓ Blue↑ Unknown Blue↑ Unknown Yellow Yellow Blue↓ Unknown Blue↑ Blue Green Blue↓ Blue Blue Blue Blue↓ Blue↑ Green↑ Blue↑ Blue↑ Pink/Magenta Blue↑ Blue↓ Blue Blue↑ Blue Blue Blue Blue Pink/Magenta↓ Blue↑ Blue Blue Blue↓ Blue↓ Blue Pink/Magenta↑ Blue↓ Pink/Magenta↓ Blue Green↓ Green↓ Blue Unknown↓ Unknown↓ Pink/Magenta↓ Yellow↑ Blue Unknown↑ Blue Blue Unknown Unknown Pink/Magenta Blue Blue Green↑ Blue↓ Blue Pink/Magenta Pink/Magenta Pink/Magenta Blue↑ Blue↑ Blue Blue Unknown Blue↓ Blue↓ Yellow Pink/Magenta↓ Pink/Magenta↓ Blue↓ Yellow↓ Green↓ Blue Blue Blue Blue Blue Blue Blue Blue Blue Blue Blue Blue Blue Blue Blue Blue Unknown Unknown↑ Yellow↑ Blue↑ Yellow↑ Blue Blue Blue Blue Blue Blue Pink/Magenta↑ Pink/Magenta↑ Blue Unknown Blue Blue Pink/Magenta Pink/Magenta Blue Blue Blue Blue Blue Blue Blue Blue Blue Blue↓ Blue↓ Blue Blue Blue Blue Blue Blue Blue Blue Blue Blue",
+  "symbol_seq_enhanced": "Blue↓ V0 Blue↑ V0 Blue↓ V0 Blue↑ V0 Unknown V0 Blue↑ V0 Unknown V0 Yellow V0 Yellow V0 Blue↓ V0 Unknown V0 Blue↑ V0 Blue V0 Green V0 Blue↓ V0 Blue V0 Blue V0 Blue V0 Blue↓ V0 Blue↑ V0 Green↑ V0 Blue↑ V0 Blue↑ V0 Pink/Magenta V0 Blue↑ V0 Blue↓ V0 Blue V0 Blue↑ V0 Blue V0 Blue V0 Blue V0 Blue V0 Pink/Magenta↓ V0 Blue↑ V0 Blue V0 Blue V0 Blue↓ V0 Blue↓ V0 Blue V0 Pink/Magenta↑ V0 Blue↓ V0 Pink/Magenta↓ V0 Blue V0 Green↓ V0 Green↓ V0 Blue V0 Unknown↓ V0 Unknown↓ V0 Pink/Magenta↓ V0 Yellow↑ V0 Blue V0 Unknown↑ V0 Blue V0 Blue V0 Unknown V0 Unknown V0 Pink/Magenta V0 Blue V0 Blue V0 Green↑ V0 Blue↓ V0 Blue V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Blue↑ V0 Blue↑ V0 Blue V0 Blue V0 Unknown V0 Blue↓ V0 Blue↓ V0 Yellow V0 Pink/Magenta↓ V0 Pink/Magenta↓ V0 Blue↓ V0 Yellow↓ V0 Green↓ V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Unknown V0 Unknown↑ V0 Yellow↑ V0 Blue↑ V0 Yellow↑ V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Pink/Magenta↑ V0 Pink/Magenta↑ V0 Blue V0 Unknown V0 Blue V0 Blue V0 Pink/Magenta V0 Pink/Magenta V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue↓ V0 Blue↓ V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0",
   "binary_seq": "00000000001000001100000000001111001001000000000000101000001110000000000001001010111110101000000000001100100000100011001111110000000000",
   "v_threshold": 0.536,
   "events": [
@@ -443,7 +443,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e000_000500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e000_000500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 1,
@@ -455,7 +463,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e001_001500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e001_001500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 2,
@@ -467,7 +483,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e002_002500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e002_002500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 3,
@@ -479,7 +503,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e003_003500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e003_003500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 4,
@@ -491,7 +523,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 53,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e004_004500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e004_004500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 5,
@@ -503,7 +542,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e005_005500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e005_005500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 6,
@@ -515,7 +562,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 49,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e006_006500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e006_006500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 7,
@@ -527,7 +581,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e007_007500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e007_007500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 8,
@@ -539,7 +600,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e008_008500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e008_008500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 9,
@@ -551,7 +619,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e009_009500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e009_009500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 10,
@@ -563,7 +639,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 9,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e010_010500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e010_010500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 11,
@@ -575,7 +658,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e011_011500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e011_011500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 12,
@@ -587,7 +678,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e012_012500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e012_012500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 13,
@@ -599,7 +697,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 65,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e013_013500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e013_013500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 14,
@@ -611,7 +716,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e014_014500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e014_014500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 15,
@@ -623,7 +736,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e015_015500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e015_015500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 16,
@@ -635,7 +755,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e016_016500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e016_016500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 17,
@@ -647,7 +774,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e017_017500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e017_017500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 18,
@@ -659,7 +793,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e018_018500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e018_018500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 19,
@@ -671,7 +813,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e019_019500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e019_019500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 20,
@@ -683,7 +833,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 45,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e020_020500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e020_020500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 21,
@@ -695,7 +853,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e021_021500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e021_021500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 22,
@@ -707,7 +873,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e022_022500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e022_022500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 23,
@@ -719,7 +893,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 29,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e023_023500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e023_023500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 24,
@@ -731,7 +912,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e024_024500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e024_024500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 25,
@@ -743,7 +932,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e025_025500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e025_025500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 26,
@@ -755,7 +952,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e026_026500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e026_026500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 27,
@@ -767,7 +971,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e027_027500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e027_027500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 28,
@@ -779,7 +991,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e028_028500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e028_028500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 29,
@@ -791,7 +1010,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e029_029500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e029_029500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 30,
@@ -803,7 +1029,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e030_030500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e030_030500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 31,
@@ -815,7 +1048,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e031_031500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e031_031500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 32,
@@ -827,7 +1067,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 44,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e032_032500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e032_032500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 33,
@@ -839,7 +1087,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e033_033500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e033_033500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 34,
@@ -851,7 +1107,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e034_034500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e034_034500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 35,
@@ -863,7 +1126,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e035_035500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e035_035500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 36,
@@ -875,7 +1145,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e036_036500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e036_036500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 37,
@@ -887,7 +1165,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e037_037500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e037_037500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 38,
@@ -899,7 +1185,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e038_038500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e038_038500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 39,
@@ -911,7 +1204,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 44,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e039_039500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e039_039500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 40,
@@ -923,7 +1224,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e040_040500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e040_040500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 41,
@@ -935,7 +1244,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 54,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e041_041500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e041_041500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 42,
@@ -947,7 +1264,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e042_042500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e042_042500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 43,
@@ -959,7 +1283,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 1,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e043_043500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e043_043500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 44,
@@ -971,7 +1303,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 1,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e044_044500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e044_044500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 45,
@@ -983,7 +1323,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e045_045500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e045_045500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 46,
@@ -995,7 +1342,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e046_046500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e046_046500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 47,
@@ -1007,7 +1362,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e047_047500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e047_047500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 48,
@@ -1019,7 +1382,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 44,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e048_048500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e048_048500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 49,
@@ -1031,7 +1402,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e049_049500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e049_049500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 50,
@@ -1043,7 +1422,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e050_050500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e050_050500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 51,
@@ -1055,7 +1441,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e051_051500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e051_051500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 52,
@@ -1067,7 +1461,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e052_052500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e052_052500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 53,
@@ -1079,7 +1480,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e053_053500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e053_053500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 54,
@@ -1091,7 +1499,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 74,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e054_054500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e054_054500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 55,
@@ -1103,7 +1518,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 74,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e055_055500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e055_055500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 56,
@@ -1115,7 +1537,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e056_056500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e056_056500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 57,
@@ -1127,7 +1556,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e057_057500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e057_057500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 58,
@@ -1139,7 +1575,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e058_058500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e058_058500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 59,
@@ -1151,7 +1594,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 56,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e059_059500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e059_059500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 60,
@@ -1163,7 +1614,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e060_060500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e060_060500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 61,
@@ -1175,7 +1634,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 34,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e061_061500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e061_061500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 62,
@@ -1187,7 +1653,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 70,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e062_062500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e062_062500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 63,
@@ -1199,7 +1672,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 70,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e063_063500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e063_063500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 64,
@@ -1211,7 +1691,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 67,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e064_064500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e064_064500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 65,
@@ -1223,7 +1710,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e065_065500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e065_065500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 66,
@@ -1235,7 +1730,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e066_066500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e066_066500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 67,
@@ -1247,7 +1750,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e067_067500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e067_067500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 68,
@@ -1259,7 +1769,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e068_068500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e068_068500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 69,
@@ -1271,7 +1788,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e069_069500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e069_069500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 70,
@@ -1283,7 +1807,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e070_070500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e070_070500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 71,
@@ -1295,7 +1827,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e071_071500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e071_071500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 72,
@@ -1307,7 +1847,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e072_072500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e072_072500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 73,
@@ -1319,7 +1866,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e073_073500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e073_073500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 74,
@@ -1331,7 +1886,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 26,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e074_074500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e074_074500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 75,
@@ -1343,7 +1906,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e075_075500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e075_075500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 76,
@@ -1355,7 +1926,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e076_076500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e076_076500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 77,
@@ -1367,7 +1946,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 56,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e077_077500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e077_077500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 78,
@@ -1379,7 +1966,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e078_078500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e078_078500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 79,
@@ -1391,7 +1985,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e079_079500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e079_079500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 80,
@@ -1403,7 +2004,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e080_080500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e080_080500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 81,
@@ -1415,7 +2023,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e081_081500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e081_081500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 82,
@@ -1427,7 +2042,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e082_082500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e082_082500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 83,
@@ -1439,7 +2061,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 34,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e083_083500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e083_083500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 84,
@@ -1451,7 +2080,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e084_084500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e084_084500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 85,
@@ -1463,7 +2099,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e085_085500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e085_085500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 86,
@@ -1475,7 +2118,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e086_086500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e086_086500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 87,
@@ -1487,7 +2137,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e087_087500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e087_087500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 88,
@@ -1499,7 +2156,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e088_088500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e088_088500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 89,
@@ -1511,7 +2175,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e089_089500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e089_089500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 90,
@@ -1523,7 +2194,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e090_090500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e090_090500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 91,
@@ -1535,7 +2213,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e091_091500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e091_091500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 92,
@@ -1547,7 +2232,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e092_092500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e092_092500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 93,
@@ -1559,7 +2251,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e093_093500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e093_093500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 94,
@@ -1571,7 +2270,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e094_094500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e094_094500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 95,
@@ -1583,7 +2289,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 27,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e095_095500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e095_095500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 96,
@@ -1595,7 +2309,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e096_096500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e096_096500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 97,
@@ -1607,7 +2329,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e097_097500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e097_097500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 98,
@@ -1619,7 +2349,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e098_098500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e098_098500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 99,
@@ -1631,7 +2369,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e099_099500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e099_099500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 100,
@@ -1643,7 +2388,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e100_100500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e100_100500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 101,
@@ -1655,7 +2407,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e101_101500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e101_101500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 102,
@@ -1667,7 +2426,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e102_102500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e102_102500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 103,
@@ -1679,7 +2445,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e103_103500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e103_103500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 104,
@@ -1691,7 +2464,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e104_104500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e104_104500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 105,
@@ -1703,7 +2483,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 31,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e105_105500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e105_105500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 106,
@@ -1715,7 +2503,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 31,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e106_106500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e106_106500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 107,
@@ -1727,7 +2523,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e107_107500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e107_107500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 108,
@@ -1739,7 +2542,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e108_108500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e108_108500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 109,
@@ -1751,7 +2561,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e109_109500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e109_109500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 110,
@@ -1763,7 +2580,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e110_110500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e110_110500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 111,
@@ -1775,7 +2599,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e111_111500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e111_111500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 112,
@@ -1787,7 +2618,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e112_112500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e112_112500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 113,
@@ -1799,7 +2637,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e113_113500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e113_113500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 114,
@@ -1811,7 +2656,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e114_114500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e114_114500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 115,
@@ -1823,7 +2675,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e115_115500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e115_115500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 116,
@@ -1835,7 +2694,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e116_116500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e116_116500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 117,
@@ -1847,7 +2713,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e117_117500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e117_117500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 118,
@@ -1859,7 +2732,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e118_118500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e118_118500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 119,
@@ -1871,7 +2751,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e119_119500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e119_119500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 120,
@@ -1883,7 +2770,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e120_120500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e120_120500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 121,
@@ -1895,7 +2789,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e121_121500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e121_121500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 122,
@@ -1907,7 +2808,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e122_122500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e122_122500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 123,
@@ -1919,7 +2828,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e123_123500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e123_123500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 124,
@@ -1931,7 +2848,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e124_124500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e124_124500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 125,
@@ -1943,7 +2867,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e125_125500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e125_125500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 126,
@@ -1955,7 +2886,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e126_126500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e126_126500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 127,
@@ -1967,7 +2905,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 2,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e127_127500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e127_127500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 128,
@@ -1979,7 +2924,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e128_128500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e128_128500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 129,
@@ -1991,7 +2943,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e129_129500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e129_129500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 130,
@@ -2003,7 +2962,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e130_130500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e130_130500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 131,
@@ -2015,7 +2981,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e131_131500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e131_131500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 132,
@@ -2027,7 +3000,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e132_132500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e132_132500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 133,
@@ -2039,11 +3019,18 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e133_133500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iifsnog65r86tlmk0g_e133_133500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     }
   ],
   "cycles": [
-    "Blue↓ Blue↑ Blue↓ Blue↑ Unknown Blue↑ Unknown Yellow Yellow Blue↓ Unknown Blue↑ Blue Green Blue↓ Blue Blue Blue Blue↓ Blue↑ Green↑ Blue↑ Blue↑ Pink/Magenta Blue↑ Blue↓ Blue Blue↑ Blue Blue Blue Blue Pink/Magenta↓ Blue↑ Blue Blue Blue↓ Blue↓ Blue Pink/Magenta↑ Blue↓ Pink/Magenta↓ Blue Green↓ Green↓ Blue Unknown↓ Unknown↓ Pink/Magenta↓ Yellow↑ Blue Unknown↑ Blue Blue Unknown Unknown Pink/Magenta Blue Blue Green↑ Blue↓ Blue Pink/Magenta Pink/Magenta Pink/Magenta Blue↑ Blue↑ Blue Blue Unknown Blue↓ Blue↓ Yellow Pink/Magenta↓ Pink/Magenta↓ Blue↓ Yellow↓ Green↓ Blue Blue Blue Blue Blue Blue Blue Blue Blue Blue Blue Blue Blue Blue Blue Blue Unknown Unknown↑ Yellow↑ Blue↑ Yellow↑ Blue Blue Blue Blue Blue Blue Pink/Magenta↑ Pink/Magenta↑ Blue Unknown Blue Blue Pink/Magenta Pink/Magenta Blue Blue Blue Blue Blue Blue Blue Blue Blue Blue↓ Blue↓ Blue Blue Blue Blue Blue Blue Blue Blue Blue Blue"
+    "Blue↓ V0 Blue↑ V0 Blue↓ V0 Blue↑ V0 Unknown V0 Blue↑ V0 Unknown V0 Yellow V0 Yellow V0 Blue↓ V0 Unknown V0 Blue↑ V0 Blue V0 Green V0 Blue↓ V0 Blue V0 Blue V0 Blue V0 Blue↓ V0 Blue↑ V0 Green↑ V0 Blue↑ V0 Blue↑ V0 Pink/Magenta V0 Blue↑ V0 Blue↓ V0 Blue V0 Blue↑ V0 Blue V0 Blue V0 Blue V0 Blue V0 Pink/Magenta↓ V0 Blue↑ V0 Blue V0 Blue V0 Blue↓ V0 Blue↓ V0 Blue V0 Pink/Magenta↑ V0 Blue↓ V0 Pink/Magenta↓ V0 Blue V0 Green↓ V0 Green↓ V0 Blue V0 Unknown↓ V0 Unknown↓ V0 Pink/Magenta↓ V0 Yellow↑ V0 Blue V0 Unknown↑ V0 Blue V0 Blue V0 Unknown V0 Unknown V0 Pink/Magenta V0 Blue V0 Blue V0 Green↑ V0 Blue↓ V0 Blue V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Blue↑ V0 Blue↑ V0 Blue V0 Blue V0 Unknown V0 Blue↓ V0 Blue↓ V0 Yellow V0 Pink/Magenta↓ V0 Pink/Magenta↓ V0 Blue↓ V0 Yellow↓ V0 Green↓ V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Unknown V0 Unknown↑ V0 Yellow↑ V0 Blue↑ V0 Yellow↑ V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Pink/Magenta↑ V0 Pink/Magenta↑ V0 Blue V0 Unknown V0 Blue V0 Blue V0 Pink/Magenta V0 Pink/Magenta V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue↓ V0 Blue↓ V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0"
   ],
   "clustering": {
     "eps": 0.34,

--- a/public/sequences_merge/v15044gf0000d2iijmvog65i9etndc70.json.sequence.json
+++ b/public/sequences_merge/v15044gf0000d2iijmvog65i9etndc70.json.sequence.json
@@ -395,7 +395,7 @@
     }
   },
   "symbol_seq": "SAJQPKLADADATANHPPEWKWWLPHIAMWPBBANUPUAMAMBSTUMWEWWUHHADHWFADWANAFAYHUANPPPAMAFADAQAQTGAQSASAAAABACFBRRAABBABABBBDSCAJAO",
-  "symbol_seq_enhanced": "Pink/Magenta Green↓ Unknown Yellow↓ Unknown↑ Unknown Yellow Yellow Unknown↓ Unknown↓ Yellow Yellow Yellow Unknown Yellow Unknown↑ Yellow↓ Yellow↓ Unknown↓ Yellow Unknown Yellow↑ Unknown↑ Yellow Yellow↑ Green Unknown Yellow Yellow Yellow↓ Unknown↓ Unknown↓ Unknown↓ Pink/Magenta↓ Yellow↓ Blue↓ Yellow Unknown Yellow Yellow Yellow↑ Yellow Yellow Yellow Yellow Yellow Blue Yellow↓ Yellow Unknown Pink/Magenta Green↑ Yellow Yellow↓ Unknown↑ Yellow Yellow Yellow Unknown↑ Pink/Magenta Yellow Green↓ Green↓ Pink/Magenta↑ Blue Green↓ Unknown Blue Unknown Pink/Magenta Pink/Magenta Blue Pink/Magenta↓ Blue↓ Blue Yellow↓ Yellow↓ Blue↑ Blue Blue↓ Blue↓ Pink/Magenta↑ Pink/Magenta↑ Blue Blue Blue↓ Unknown Blue↓ Green↓ Green↑",
+  "symbol_seq_enhanced": "Pink/Magenta V0 Green↓ V0 Unknown V0 Yellow↓ V0 Unknown↑ V0 Unknown V0 Yellow V0 Yellow V0 Unknown↓ V0 Unknown↓ V0 Yellow V0 Yellow V0 Yellow V0 Unknown V0 Yellow V0 Unknown↑ V0 Yellow↓ V0 Yellow↓ V0 Unknown↓ V0 Yellow V0 Unknown V0 Yellow↑ V0 Unknown↑ V0 Yellow V0 Yellow↑ V0 Green V0 Unknown V0 Yellow V0 Yellow V0 Yellow↓ V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Pink/Magenta↓ V0 Yellow↓ V0 Blue↓ V0 Yellow V0 Unknown V0 Yellow V0 Yellow V0 Yellow↑ V0 Yellow V0 Yellow V0 Yellow V0 Yellow V0 Yellow V0 Blue V0 Yellow↓ V0 Yellow V0 Unknown V0 Pink/Magenta V0 Green↑ V0 Yellow V0 Yellow↓ V0 Unknown↑ V0 Yellow V0 Yellow V0 Yellow V0 Unknown↑ V0 Pink/Magenta V0 Yellow V0 Green↓ V0 Green↓ V0 Pink/Magenta↑ V0 Blue V0 Green↓ V0 Unknown V0 Blue V0 Unknown V0 Pink/Magenta V0 Pink/Magenta V0 Blue V0 Pink/Magenta↓ V0 Blue↓ V0 Blue V0 Yellow↓ V0 Yellow↓ V0 Blue↑ V0 Blue V0 Blue↓ V0 Blue↓ V0 Pink/Magenta↑ V0 Pink/Magenta↑ V0 Blue V0 Blue V0 Blue↓ V0 Unknown V0 Blue↓ V0 Green↓ V0 Green↑ V0",
   "binary_seq": "101000000000000011100000000000111001000001101010000001000000000010000001101110000000000001",
   "v_threshold": 0.544,
   "events": [
@@ -409,7 +409,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e000_000250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e000_000250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 1,
@@ -421,7 +428,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 24,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e001_000750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e001_000750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 2,
@@ -433,7 +448,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e002_001250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e002_001250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 3,
@@ -445,7 +467,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e003_001750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e003_001750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 4,
@@ -457,7 +487,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e004_002250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e004_002250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 5,
@@ -469,7 +507,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e005_002750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e005_002750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 6,
@@ -481,7 +526,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 5,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e006_003250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e006_003250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 7,
@@ -493,7 +545,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 5,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e007_003750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e007_003750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 8,
@@ -505,7 +564,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 32,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e008_004250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e008_004250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 9,
@@ -517,7 +584,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 27,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e009_004750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e009_004750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 10,
@@ -529,7 +604,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e010_005250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e010_005250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 11,
@@ -541,7 +623,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e011_005750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e011_005750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 12,
@@ -553,7 +642,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e012_006250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e012_006250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 13,
@@ -565,7 +661,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e013_006750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e013_006750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 14,
@@ -577,7 +680,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e014_007250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e014_007250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 15,
@@ -589,7 +699,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e015_007750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e015_007750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 16,
@@ -601,7 +719,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e016_008250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e016_008250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 17,
@@ -613,7 +739,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e017_008750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e017_008750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 18,
@@ -625,7 +759,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e018_009250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e018_009250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 19,
@@ -637,7 +779,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e019_009750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e019_009750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 20,
@@ -649,7 +798,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e020_010250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e020_010250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 21,
@@ -661,7 +817,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e021_010750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e021_010750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 22,
@@ -673,7 +837,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 7,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e022_011250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e022_011250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 23,
@@ -685,7 +857,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e023_011750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e023_011750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 24,
@@ -697,7 +876,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e024_012250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e024_012250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 25,
@@ -709,7 +896,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 66,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e025_012750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e025_012750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 26,
@@ -721,7 +915,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 27,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e026_013250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e026_013250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 27,
@@ -733,7 +934,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e027_013750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e027_013750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 28,
@@ -745,7 +953,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e028_014250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e028_014250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 29,
@@ -757,7 +972,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e029_014750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e029_014750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 30,
@@ -769,7 +992,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 7,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e030_015250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e030_015250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 31,
@@ -781,7 +1012,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 7,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e031_015750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e031_015750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 32,
@@ -793,7 +1032,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 73,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e032_016250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e032_016250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 33,
@@ -805,7 +1052,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e033_016750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e033_016750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 34,
@@ -817,7 +1072,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e034_017250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e034_017250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 35,
@@ -829,7 +1092,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e035_017750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e035_017750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 36,
@@ -841,7 +1112,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e036_018250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e036_018250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 37,
@@ -853,7 +1131,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e037_018750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e037_018750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 38,
@@ -865,7 +1150,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e038_019250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e038_019250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 39,
@@ -877,7 +1169,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e039_019750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e039_019750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 40,
@@ -889,7 +1188,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e040_020250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e040_020250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 41,
@@ -901,7 +1208,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e041_020750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e041_020750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 42,
@@ -913,7 +1227,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e042_021250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e042_021250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 43,
@@ -925,7 +1246,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 5,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e043_021750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e043_021750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 44,
@@ -937,7 +1265,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e044_022250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e044_022250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 45,
@@ -949,7 +1284,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e045_022750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e045_022750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 46,
@@ -961,7 +1303,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e046_023250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e046_023250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 47,
@@ -973,7 +1322,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 5,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e047_023750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e047_023750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 48,
@@ -985,7 +1342,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e048_024250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e048_024250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 49,
@@ -997,7 +1361,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 27,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e049_024750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e049_024750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 50,
@@ -1009,7 +1380,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 54,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e050_025250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e050_025250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 51,
@@ -1021,7 +1399,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 45,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e051_025750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e051_025750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 52,
@@ -1033,7 +1419,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e052_026250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e052_026250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 53,
@@ -1045,7 +1438,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e053_026750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e053_026750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 54,
@@ -1057,7 +1458,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 27,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e054_027250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e054_027250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 55,
@@ -1069,7 +1478,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e055_027750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e055_027750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 56,
@@ -1081,7 +1497,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e056_028250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e056_028250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 57,
@@ -1093,7 +1516,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e057_028750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e057_028750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 58,
@@ -1105,7 +1535,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 7,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e058_029250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e058_029250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 59,
@@ -1117,7 +1555,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 54,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e059_029750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e059_029750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 60,
@@ -1129,7 +1574,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 5,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e060_030250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e060_030250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 61,
@@ -1141,7 +1593,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 65,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e061_030750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e061_030750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 62,
@@ -1153,7 +1613,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 65,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e062_031250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e062_031250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 63,
@@ -1165,7 +1633,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e063_031750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e063_031750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 64,
@@ -1177,7 +1653,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e064_032250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e064_032250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 65,
@@ -1189,7 +1672,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 65,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e065_032750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e065_032750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 66,
@@ -1201,7 +1692,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e066_033250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e066_033250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 67,
@@ -1213,7 +1711,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e067_033750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e067_033750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 68,
@@ -1225,7 +1730,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e068_034250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e068_034250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 69,
@@ -1237,7 +1749,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 70,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e069_034750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e069_034750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 70,
@@ -1249,7 +1768,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 70,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e070_035250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e070_035250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 71,
@@ -1261,7 +1787,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e071_035750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e071_035750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 72,
@@ -1273,7 +1806,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 38,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e072_036250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e072_036250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 73,
@@ -1285,7 +1826,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e073_036750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e073_036750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 74,
@@ -1297,7 +1846,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e074_037250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e074_037250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 75,
@@ -1309,7 +1865,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e075_037750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e075_037750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 76,
@@ -1321,7 +1885,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e076_038250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e076_038250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 77,
@@ -1333,7 +1905,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e077_038750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e077_038750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 78,
@@ -1345,7 +1925,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e078_039250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e078_039250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 79,
@@ -1357,7 +1944,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e079_039750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e079_039750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 80,
@@ -1369,7 +1964,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e080_040250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e080_040250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 81,
@@ -1381,7 +1984,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 44,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e081_040750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e081_040750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 82,
@@ -1393,7 +2004,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 44,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e082_041250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e082_041250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 83,
@@ -1405,7 +2024,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e083_041750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e083_041750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 84,
@@ -1417,7 +2043,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e084_042250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e084_042250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 85,
@@ -1429,7 +2062,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e085_042750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e085_042750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 86,
@@ -1441,7 +2082,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e086_043250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e086_043250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 87,
@@ -1453,7 +2101,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e087_043750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e087_043750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 88,
@@ -1465,7 +2121,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 24,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e088_044250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e088_044250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 89,
@@ -1477,11 +2141,19 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 41,
-      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e089_044750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2iijmvog65i9etndc70_e089_044750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     }
   ],
   "cycles": [
-    "Pink/Magenta Green↓ Unknown Yellow↓ Unknown↑ Unknown Yellow Yellow Unknown↓ Unknown↓ Yellow Yellow Yellow Unknown Yellow Unknown↑ Yellow↓ Yellow↓ Unknown↓ Yellow Unknown Yellow↑ Unknown↑ Yellow Yellow↑ Green Unknown Yellow Yellow Yellow↓ Unknown↓ Unknown↓ Unknown↓ Pink/Magenta↓ Yellow↓ Blue↓ Yellow Unknown Yellow Yellow Yellow↑ Yellow Yellow Yellow Yellow Yellow Blue Yellow↓ Yellow Unknown Pink/Magenta Green↑ Yellow Yellow↓ Unknown↑ Yellow Yellow Yellow Unknown↑ Pink/Magenta Yellow Green↓ Green↓ Pink/Magenta↑ Blue Green↓ Unknown Blue Unknown Pink/Magenta Pink/Magenta Blue Pink/Magenta↓ Blue↓ Blue Yellow↓ Yellow↓ Blue↑ Blue Blue↓ Blue↓ Pink/Magenta↑ Pink/Magenta↑ Blue Blue Blue↓ Unknown Blue↓ Green↓ Green↑"
+    "Pink/Magenta V0 Green↓ V0 Unknown V0 Yellow↓ V0 Unknown↑ V0 Unknown V0 Yellow V0 Yellow V0 Unknown↓ V0 Unknown↓ V0 Yellow V0 Yellow V0 Yellow V0 Unknown V0 Yellow V0 Unknown↑ V0 Yellow↓ V0 Yellow↓ V0 Unknown↓ V0 Yellow V0 Unknown V0 Yellow↑ V0 Unknown↑ V0 Yellow V0 Yellow↑ V0 Green V0 Unknown V0 Yellow V0 Yellow V0 Yellow↓ V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Pink/Magenta↓ V0 Yellow↓ V0 Blue↓ V0 Yellow V0 Unknown V0 Yellow V0 Yellow V0 Yellow↑ V0 Yellow V0 Yellow V0 Yellow V0 Yellow V0 Yellow V0 Blue V0 Yellow↓ V0 Yellow V0 Unknown V0 Pink/Magenta V0 Green↑ V0 Yellow V0 Yellow↓ V0 Unknown↑ V0 Yellow V0 Yellow V0 Yellow V0 Unknown↑ V0 Pink/Magenta V0 Yellow V0 Green↓ V0 Green↓ V0 Pink/Magenta↑ V0 Blue V0 Green↓ V0 Unknown V0 Blue V0 Unknown V0 Pink/Magenta V0 Pink/Magenta V0 Blue V0 Pink/Magenta↓ V0 Blue↓ V0 Blue V0 Yellow↓ V0 Yellow↓ V0 Blue↑ V0 Blue V0 Blue↓ V0 Blue↓ V0 Pink/Magenta↑ V0 Pink/Magenta↑ V0 Blue V0 Blue V0 Blue↓ V0 Unknown V0 Blue↓ V0 Green↓ V0 Green↑ V0"
   ],
   "clustering": {
     "eps": 0.34,

--- a/public/sequences_merge/v15044gf0000d2j6b17og65tfia5e8sg.json.sequence.json
+++ b/public/sequences_merge/v15044gf0000d2j6b17og65tfia5e8sg.json.sequence.json
@@ -395,7 +395,7 @@
     }
   },
   "symbol_seq": "DASSSAIABVACOVTCVAVAKAKGAWACSSACACAAPCAIAFAFVABAAKJGJMOFXOFFACAGXAEABACAKHAHAGABAAAAVAIAAJZAFANWUAHASVVAFMJAIAWAWTVVAGARARAGAAAKVZZAUAVVNCBBCCAFFJZSAFFMMMJJGMAGAGAGGAEMSIVAAVJVEMJJMJJJMJJMMT",
-  "symbol_seq_enhanced": "Blue Unknown Unknown↑ Unknown↑ Pink/Magenta↑ Pink/Magenta↑ Pink/Magenta↑ Pink/Magenta Blue↓ Pink/Magenta↓ Pink/Magenta Blue↓ Pink/Magenta Unknown↓ Pink/Magenta↑ Pink/Magenta↑ Blue Unknown↑ Pink/Magenta Unknown Unknown Pink/Magenta Pink/Magenta Pink/Magenta↓ Yellow Blue Pink/Magenta↓ Pink/Magenta↓ Pink/Magenta↓ Pink/Magenta↑ Pink/Magenta Pink/Magenta↓ Unknown↑ Blue Blue Blue Blue Blue Blue Blue Blue Blue Blue Pink/Magenta↑ Pink/Magenta↓ Unknown↓ Blue Pink/Magenta↓ Pink/Magenta Pink/Magenta↓ Yellow↓ Pink/Magenta↑ Pink/Magenta Pink/Magenta↑ Pink/Magenta Pink/Magenta Pink/Magenta↓ Pink/Magenta Pink/Magenta↓ Blue↓ Blue Pink/Magenta Unknown↓ Yellow Yellow Pink/Magenta Unknown↑ Pink/Magenta↑ Pink/Magenta↑ Pink/Magenta↓ Blue↓ Blue↓ Pink/Magenta↓ Unknown↑ Unknown↑ Pink/Magenta↓ Pink/Magenta↓ Pink/Magenta Pink/Magenta↑ Unknown Unknown Pink/Magenta Pink/Magenta↑ Pink/Magenta Pink/Magenta↑ Unknown Unknown Green↑ Blue↑ Pink/Magenta Pink/Magenta Blue Blue Blue Blue Blue Blue Blue Blue Blue Blue Blue↓ Unknown Pink/Magenta↓ Blue↑ Blue Blue Blue Blue Blue Blue Blue Pink/Magenta↓ Pink/Magenta↓ Pink/Magenta↓ Blue Blue↓ Blue Unknown↓ Yellow Pink/Magenta Pink/Magenta↓ Pink/Magenta Blue Pink/Magenta Unknown Blue Blue Blue Blue Blue Blue Blue↓ Blue Blue↓ Blue↓ Blue Blue Pink/Magenta↓",
+  "symbol_seq_enhanced": "Blue V0 Unknown V0 Unknown↑ V0 Unknown↑ V0 Pink/Magenta↑ V0 Pink/Magenta↑ V0 Pink/Magenta↑ V0 Pink/Magenta V0 Blue↓ V0 Pink/Magenta↓ V0 Pink/Magenta V0 Blue↓ V0 Pink/Magenta V0 Unknown↓ V0 Pink/Magenta↑ V0 Pink/Magenta↑ V0 Blue V0 Unknown↑ V0 Pink/Magenta V0 Unknown V0 Unknown V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta↓ V0 Yellow V0 Blue V0 Pink/Magenta↓ V0 Pink/Magenta↓ V0 Pink/Magenta↓ V0 Pink/Magenta↑ V0 Pink/Magenta V0 Pink/Magenta↓ V0 Unknown↑ V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Pink/Magenta↑ V0 Pink/Magenta↓ V0 Unknown↓ V0 Blue V0 Pink/Magenta↓ V0 Pink/Magenta V0 Pink/Magenta↓ V0 Yellow↓ V0 Pink/Magenta↑ V0 Pink/Magenta V0 Pink/Magenta↑ V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta↓ V0 Pink/Magenta V0 Pink/Magenta↓ V0 Blue↓ V0 Blue V0 Pink/Magenta V0 Unknown↓ V0 Yellow V0 Yellow V0 Pink/Magenta V0 Unknown↑ V0 Pink/Magenta↑ V0 Pink/Magenta↑ V0 Pink/Magenta↓ V0 Blue↓ V0 Blue↓ V0 Pink/Magenta↓ V0 Unknown↑ V0 Unknown↑ V0 Pink/Magenta↓ V0 Pink/Magenta↓ V0 Pink/Magenta V0 Pink/Magenta↑ V0 Unknown V0 Unknown V0 Pink/Magenta V0 Pink/Magenta↑ V0 Pink/Magenta V0 Pink/Magenta↑ V0 Unknown V0 Unknown V0 Green↑ V0 Blue↑ V0 Pink/Magenta V0 Pink/Magenta V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue↓ V0 Unknown V0 Pink/Magenta↓ V0 Blue↑ V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Pink/Magenta↓ V0 Pink/Magenta↓ V0 Pink/Magenta↓ V0 Blue V0 Blue↓ V0 Blue V0 Unknown↓ V0 Yellow V0 Pink/Magenta V0 Pink/Magenta↓ V0 Pink/Magenta V0 Blue V0 Pink/Magenta V0 Unknown V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue↓ V0 Blue V0 Blue↓ V0 Blue↓ V0 Blue V0 Blue V0 Pink/Magenta↓ V0",
   "binary_seq": "1011000000000100010100010000000011111010001000110000011100100000000000001001000110000111100100011011100101101111100101100010001111011100010",
   "v_threshold": 0.506,
   "events": [
@@ -409,7 +409,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e000_000500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e000_000500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 1,
@@ -421,7 +428,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 64,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e001_001500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e001_001500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 2,
@@ -433,7 +447,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e002_002500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e002_002500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 3,
@@ -445,7 +467,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e003_003500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e003_003500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 4,
@@ -457,7 +487,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 67,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e004_004500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e004_004500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 5,
@@ -469,7 +507,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 44,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e005_005500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e005_005500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 6,
@@ -481,7 +527,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e006_006500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e006_006500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 7,
@@ -493,7 +547,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 38,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e007_007500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e007_007500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 8,
@@ -505,7 +566,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e008_008500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e008_008500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 9,
@@ -517,7 +586,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e009_009500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e009_009500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 10,
@@ -529,7 +606,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e010_010500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e010_010500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 11,
@@ -541,7 +625,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e011_011500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e011_011500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 12,
@@ -553,7 +645,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e012_012500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e012_012500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 13,
@@ -565,7 +664,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 53,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e013_013500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e013_013500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 14,
@@ -577,7 +684,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 29,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e014_014500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e014_014500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 15,
@@ -589,7 +704,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 29,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e015_015500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e015_015500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 16,
@@ -601,7 +724,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e016_016500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e016_016500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 17,
@@ -613,7 +743,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 58,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e017_017500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e017_017500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 18,
@@ -625,7 +763,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 38,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e018_018500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e018_018500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 19,
@@ -637,7 +782,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e019_019500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e019_019500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 20,
@@ -649,7 +801,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e020_020500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e020_020500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 21,
@@ -661,7 +820,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 38,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e021_021500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e021_021500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 22,
@@ -673,7 +839,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 38,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e022_022500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e022_022500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 23,
@@ -685,7 +858,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 70,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e023_023500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e023_023500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 24,
@@ -697,7 +878,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e024_024500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e024_024500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 25,
@@ -709,7 +897,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e025_025500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e025_025500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 26,
@@ -721,7 +916,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 67,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e026_026500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e026_026500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 27,
@@ -733,7 +936,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 54,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e027_027500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e027_027500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 28,
@@ -745,7 +956,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 54,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e028_028500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e028_028500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 29,
@@ -757,7 +976,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e029_029500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e029_029500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 30,
@@ -769,7 +996,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 44,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e030_030500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e030_030500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 31,
@@ -781,7 +1015,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 70,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e031_031500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e031_031500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 32,
@@ -793,7 +1035,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e032_032500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e032_032500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 33,
@@ -805,7 +1055,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e033_033500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e033_033500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 34,
@@ -817,7 +1074,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e034_034500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e034_034500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 35,
@@ -829,7 +1093,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e035_035500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e035_035500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 36,
@@ -841,7 +1112,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e036_036500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e036_036500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 37,
@@ -853,7 +1131,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e037_037500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e037_037500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 38,
@@ -865,7 +1150,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e038_038500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e038_038500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 39,
@@ -877,7 +1169,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 2,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e039_039500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e039_039500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 40,
@@ -889,7 +1188,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e040_040500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e040_040500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 41,
@@ -901,7 +1207,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e041_041500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e041_041500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 42,
@@ -913,7 +1226,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e042_042500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e042_042500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 43,
@@ -925,7 +1245,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 38,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e043_043500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e043_043500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 44,
@@ -937,7 +1265,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 26,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e044_044500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e044_044500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 45,
@@ -949,7 +1285,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 2,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e045_045500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e045_045500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 46,
@@ -961,7 +1305,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 34,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e046_046500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e046_046500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 47,
@@ -973,7 +1324,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 44,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e047_047500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e047_047500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 48,
@@ -985,7 +1344,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 38,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e048_048500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e048_048500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 49,
@@ -997,7 +1363,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 29,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e049_049500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e049_049500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 50,
@@ -1009,7 +1383,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e050_050500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e050_050500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 51,
@@ -1021,7 +1403,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 31,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e051_051500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e051_051500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 52,
@@ -1033,7 +1423,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 26,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e052_052500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e052_052500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 53,
@@ -1045,7 +1442,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 44,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e053_053500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e053_053500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 54,
@@ -1057,7 +1462,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 70,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e054_054500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e054_054500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 55,
@@ -1069,7 +1481,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 70,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e055_055500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e055_055500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 56,
@@ -1081,7 +1500,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e056_056500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e056_056500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 57,
@@ -1093,7 +1520,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 67,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e057_057500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e057_057500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 58,
@@ -1105,7 +1539,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 70,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e058_058500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e058_058500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 59,
@@ -1117,7 +1559,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e059_059500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e059_059500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 60,
@@ -1129,7 +1579,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 49,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e060_060500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e060_060500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 61,
@@ -1141,7 +1598,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 54,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e061_061500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e061_061500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 62,
@@ -1153,7 +1617,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 27,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e062_062500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e062_062500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 63,
@@ -1165,7 +1637,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e063_063500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e063_063500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 64,
@@ -1177,7 +1656,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e064_064500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e064_064500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 65,
@@ -1189,7 +1675,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 31,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e065_065500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e065_065500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 66,
@@ -1201,7 +1694,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 64,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e066_066500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e066_066500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 67,
@@ -1213,7 +1714,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e067_067500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e067_067500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 68,
@@ -1225,7 +1734,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e068_068500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e068_068500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 69,
@@ -1237,7 +1754,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 54,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e069_069500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e069_069500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 70,
@@ -1249,7 +1774,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e070_070500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e070_070500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 71,
@@ -1261,7 +1794,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e071_071500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e071_071500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 72,
@@ -1273,7 +1814,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 67,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e072_072500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e072_072500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 73,
@@ -1285,7 +1834,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 58,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e073_073500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e073_073500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 74,
@@ -1297,7 +1854,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 58,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e074_074500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e074_074500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 75,
@@ -1309,7 +1874,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e075_075500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e075_075500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 76,
@@ -1321,7 +1894,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e076_076500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e076_076500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 77,
@@ -1333,7 +1914,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e077_077500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e077_077500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 78,
@@ -1345,7 +1933,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 26,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e078_078500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e078_078500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 79,
@@ -1357,7 +1953,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 42,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e079_079500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e079_079500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 80,
@@ -1369,7 +1972,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 42,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e080_080500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e080_080500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 81,
@@ -1381,7 +1991,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 26,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e081_081500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e081_081500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 82,
@@ -1393,7 +2010,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 70,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e082_082500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e082_082500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 83,
@@ -1405,7 +2030,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 29,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e083_083500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e083_083500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 84,
@@ -1417,7 +2049,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e084_084500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e084_084500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 85,
@@ -1429,7 +2069,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 49,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e085_085500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e085_085500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 86,
@@ -1441,7 +2088,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 49,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e086_086500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e086_086500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 87,
@@ -1453,7 +2107,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 56,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e087_087500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e087_087500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 88,
@@ -1465,7 +2127,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e088_088500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e088_088500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 89,
@@ -1477,7 +2147,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e089_089500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e089_089500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 90,
@@ -1489,7 +2166,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e090_090500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e090_090500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 91,
@@ -1501,7 +2185,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e091_091500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e091_091500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 92,
@@ -1513,7 +2204,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e092_092500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e092_092500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 93,
@@ -1525,7 +2223,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e093_093500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e093_093500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 94,
@@ -1537,7 +2242,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e094_094500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e094_094500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 95,
@@ -1549,7 +2261,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e095_095500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e095_095500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 96,
@@ -1561,7 +2280,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e096_096500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e096_096500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 97,
@@ -1573,7 +2299,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e097_097500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e097_097500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 98,
@@ -1585,7 +2318,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e098_098500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e098_098500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 99,
@@ -1597,7 +2337,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e099_099500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e099_099500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 100,
@@ -1609,7 +2356,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e100_100500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e100_100500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 101,
@@ -1621,7 +2375,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 49,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e101_101500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e101_101500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 102,
@@ -1633,7 +2395,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e102_102500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e102_102500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 103,
@@ -1645,7 +2414,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 54,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e103_103500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e103_103500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 104,
@@ -1657,7 +2434,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e104_104500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e104_104500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 105,
@@ -1669,7 +2454,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e105_105500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e105_105500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 106,
@@ -1681,7 +2473,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e106_106500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e106_106500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 107,
@@ -1693,7 +2492,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e107_107500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e107_107500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 108,
@@ -1705,7 +2511,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e108_108500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e108_108500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 109,
@@ -1717,7 +2530,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e109_109500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e109_109500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 110,
@@ -1729,7 +2549,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e110_110500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e110_110500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 111,
@@ -1741,7 +2568,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e111_111500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e111_111500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 112,
@@ -1753,7 +2587,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 26,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e112_112500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e112_112500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 113,
@@ -1765,7 +2607,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 26,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e113_113500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e113_113500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 114,
@@ -1777,7 +2627,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 26,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e114_114500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e114_114500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 115,
@@ -1789,7 +2647,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e115_115500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e115_115500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 116,
@@ -1801,7 +2666,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 34,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e116_116500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e116_116500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 117,
@@ -1813,7 +2686,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e117_117500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e117_117500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 118,
@@ -1825,7 +2705,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e118_118500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e118_118500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 119,
@@ -1837,7 +2725,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e119_119500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e119_119500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 120,
@@ -1849,7 +2744,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e120_120500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e120_120500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 121,
@@ -1861,7 +2763,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 70,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e121_121500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e121_121500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 122,
@@ -1873,7 +2783,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e122_122500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e122_122500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 123,
@@ -1885,7 +2802,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e123_123500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e123_123500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 124,
@@ -1897,7 +2821,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e124_124500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e124_124500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 125,
@@ -1909,7 +2840,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e125_125500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e125_125500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 126,
@@ -1921,7 +2859,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e126_126500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e126_126500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 127,
@@ -1933,7 +2878,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e127_127500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e127_127500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 128,
@@ -1945,7 +2897,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e128_128500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e128_128500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 129,
@@ -1957,7 +2916,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e129_129500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e129_129500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 130,
@@ -1969,7 +2935,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e130_130500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e130_130500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 131,
@@ -1981,7 +2954,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e131_131500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e131_131500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 132,
@@ -1993,7 +2973,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e132_132500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e132_132500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 133,
@@ -2005,7 +2993,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e133_133500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e133_133500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 134,
@@ -2017,7 +3012,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e134_134500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e134_134500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 135,
@@ -2029,7 +3032,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e135_135500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e135_135500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 136,
@@ -2041,7 +3052,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e136_136500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e136_136500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 137,
@@ -2053,7 +3071,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e137_137500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e137_137500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 138,
@@ -2065,11 +3090,19 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e138_138500_obj.jpg"
+      "thumb_obj": "v15044gf0000d2j6b17og65tfia5e8sg_e138_138500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     }
   ],
   "cycles": [
-    "Blue Unknown Unknown↑ Unknown↑ Pink/Magenta↑ Pink/Magenta↑ Pink/Magenta↑ Pink/Magenta Blue↓ Pink/Magenta↓ Pink/Magenta Blue↓ Pink/Magenta Unknown↓ Pink/Magenta↑ Pink/Magenta↑ Blue Unknown↑ Pink/Magenta Unknown Unknown Pink/Magenta Pink/Magenta Pink/Magenta↓ Yellow Blue Pink/Magenta↓ Pink/Magenta↓ Pink/Magenta↓ Pink/Magenta↑ Pink/Magenta Pink/Magenta↓ Unknown↑ Blue Blue Blue Blue Blue Blue Blue Blue Blue Blue Pink/Magenta↑ Pink/Magenta↓ Unknown↓ Blue Pink/Magenta↓ Pink/Magenta Pink/Magenta↓ Yellow↓ Pink/Magenta↑ Pink/Magenta Pink/Magenta↑ Pink/Magenta Pink/Magenta Pink/Magenta↓ Pink/Magenta Pink/Magenta↓ Blue↓ Blue Pink/Magenta Unknown↓ Yellow Yellow Pink/Magenta Unknown↑ Pink/Magenta↑ Pink/Magenta↑ Pink/Magenta↓ Blue↓ Blue↓ Pink/Magenta↓ Unknown↑ Unknown↑ Pink/Magenta↓ Pink/Magenta↓ Pink/Magenta Pink/Magenta↑ Unknown Unknown Pink/Magenta Pink/Magenta↑ Pink/Magenta Pink/Magenta↑ Unknown Unknown Green↑ Blue↑ Pink/Magenta Pink/Magenta Blue Blue Blue Blue Blue Blue Blue Blue Blue Blue Blue↓ Unknown Pink/Magenta↓ Blue↑ Blue Blue Blue Blue Blue Blue Blue Pink/Magenta↓ Pink/Magenta↓ Pink/Magenta↓ Blue Blue↓ Blue Unknown↓ Yellow Pink/Magenta Pink/Magenta↓ Pink/Magenta Blue Pink/Magenta Unknown Blue Blue Blue Blue Blue Blue Blue↓ Blue Blue↓ Blue↓ Blue Blue Pink/Magenta↓"
+    "Blue V0 Unknown V0 Unknown↑ V0 Unknown↑ V0 Pink/Magenta↑ V0 Pink/Magenta↑ V0 Pink/Magenta↑ V0 Pink/Magenta V0 Blue↓ V0 Pink/Magenta↓ V0 Pink/Magenta V0 Blue↓ V0 Pink/Magenta V0 Unknown↓ V0 Pink/Magenta↑ V0 Pink/Magenta↑ V0 Blue V0 Unknown↑ V0 Pink/Magenta V0 Unknown V0 Unknown V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta↓ V0 Yellow V0 Blue V0 Pink/Magenta↓ V0 Pink/Magenta↓ V0 Pink/Magenta↓ V0 Pink/Magenta↑ V0 Pink/Magenta V0 Pink/Magenta↓ V0 Unknown↑ V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Pink/Magenta↑ V0 Pink/Magenta↓ V0 Unknown↓ V0 Blue V0 Pink/Magenta↓ V0 Pink/Magenta V0 Pink/Magenta↓ V0 Yellow↓ V0 Pink/Magenta↑ V0 Pink/Magenta V0 Pink/Magenta↑ V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta↓ V0 Pink/Magenta V0 Pink/Magenta↓ V0 Blue↓ V0 Blue V0 Pink/Magenta V0 Unknown↓ V0 Yellow V0 Yellow V0 Pink/Magenta V0 Unknown↑ V0 Pink/Magenta↑ V0 Pink/Magenta↑ V0 Pink/Magenta↓ V0 Blue↓ V0 Blue↓ V0 Pink/Magenta↓ V0 Unknown↑ V0 Unknown↑ V0 Pink/Magenta↓ V0 Pink/Magenta↓ V0 Pink/Magenta V0 Pink/Magenta↑ V0 Unknown V0 Unknown V0 Pink/Magenta V0 Pink/Magenta↑ V0 Pink/Magenta V0 Pink/Magenta↑ V0 Unknown V0 Unknown V0 Green↑ V0 Blue↑ V0 Pink/Magenta V0 Pink/Magenta V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue↓ V0 Unknown V0 Pink/Magenta↓ V0 Blue↑ V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Pink/Magenta↓ V0 Pink/Magenta↓ V0 Pink/Magenta↓ V0 Blue V0 Blue↓ V0 Blue V0 Unknown↓ V0 Yellow V0 Pink/Magenta V0 Pink/Magenta↓ V0 Pink/Magenta V0 Blue V0 Pink/Magenta V0 Unknown V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue↓ V0 Blue V0 Blue↓ V0 Blue↓ V0 Blue V0 Blue V0 Pink/Magenta↓ V0"
   ],
   "clustering": {
     "eps": 0.34,

--- a/public/sequences_merge/v15044gf0000d2jrvv7og65q7lr92if0.json.sequence.json
+++ b/public/sequences_merge/v15044gf0000d2jrvv7og65q7lr92if0.json.sequence.json
@@ -378,7 +378,7 @@
     }
   },
   "symbol_seq": "RIWBDQQZJLAIPKANYATACKLJEQHAZHQLAEQHPRH_PEEHRIHIRESEPRWURPPYAGYLAARICLHREPLANKPAERNEAHYXSSS",
-  "symbol_seq_enhanced": "Yellow Yellow Yellow Unknown↓ Unknown↓ Unknown↓ Blue Blue↓ Unknown Pink/Magenta↓ Yellow↓ Unknown↑ Unknown Unknown↑ Unknown↓ Pink/Magenta↑ Unknown Unknown Blue Unknown↓ Unknown Unknown↓ Unknown↓ Yellow↓ Unknown Unknown↑ Blue↓ Unknown↓ Yellow Yellow Yellow↑ Yellow↓ Unknown Yellow Unknown Unknown Yellow↓ Yellow↑ Yellow Yellow↑ Yellow Yellow Unknown Unknown Unknown Yellow Yellow↓ Yellow↓ Yellow↓ Yellow↓ Yellow Yellow↑ Unknown Pink/Magenta↓ Unknown Unknown Pink/Magenta↑ Yellow Yellow↑ Blue Unknown↓ Yellow Yellow↑ Unknown Yellow Unknown↓ Unknown↓ Unknown Yellow↓ Blue Yellow↑ Blue↓ Unknown Pink/Magenta↓ Unknown Unknown Unknown Unknown Unknown",
+  "symbol_seq_enhanced": "Yellow V0 Yellow V0 Yellow V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Blue V0 Blue↓ V0 Unknown V0 Pink/Magenta↓ V0 Yellow↓ V0 Unknown↑ V0 Unknown V0 Unknown↑ V0 Unknown↓ V0 Pink/Magenta↑ V0 Unknown V0 Unknown V0 Blue V0 Unknown↓ V0 Unknown V0 Unknown↓ V0 Unknown↓ V0 Yellow↓ V0 Unknown V0 Unknown↑ V0 Blue↓ V0 Unknown↓ V0 Yellow V0 Yellow V0 Yellow↑ V0 Yellow↓ V0 Unknown V0 Yellow V0 Unknown V0 Unknown V0 Yellow↓ V0 Yellow↑ V0 Yellow V0 Yellow↑ V0 Yellow V0 Yellow V0 Unknown V0 Unknown V0 Unknown V0 Yellow V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow V0 Yellow↑ V0 Unknown V0 Pink/Magenta↓ V0 Unknown V0 Unknown V0 Pink/Magenta↑ V0 Yellow V0 Yellow↑ V0 Blue V0 Unknown↓ V0 Yellow V0 Yellow↑ V0 Unknown V0 Yellow V0 Unknown↓ V0 Unknown↓ V0 Unknown V0 Yellow↓ V0 Blue V0 Yellow↑ V0 Blue↓ V0 Unknown V0 Pink/Magenta↓ V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0",
   "binary_seq": "0000000001101111001000101100010010110000001000011111000000000100100000010000000",
   "v_threshold": 0.5820000000000001,
   "events": [
@@ -392,7 +392,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e000_000250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e000_000250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 1,
@@ -404,7 +411,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e001_000750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e001_000750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 2,
@@ -416,7 +430,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e002_001250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e002_001250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 3,
@@ -428,7 +449,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 59,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e003_001750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e003_001750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 4,
@@ -440,7 +469,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e004_002250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e004_002250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 5,
@@ -452,7 +489,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e005_002750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e005_002750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 6,
@@ -464,7 +509,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 49,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e006_003250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e006_003250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 7,
@@ -476,7 +528,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e007_003750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e007_003750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 8,
@@ -488,7 +548,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e008_004250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e008_004250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 9,
@@ -500,7 +567,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 67,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e009_004750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e009_004750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 10,
@@ -512,7 +587,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e010_005250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e010_005250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 11,
@@ -524,7 +607,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e011_005750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e011_005750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 12,
@@ -536,7 +627,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 27,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e012_006250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e012_006250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 13,
@@ -548,7 +646,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e013_006750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e013_006750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 14,
@@ -560,7 +666,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 32,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e014_007250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e014_007250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 15,
@@ -572,7 +686,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 38,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e015_007750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e015_007750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 16,
@@ -584,7 +706,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e016_008250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e016_008250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 17,
@@ -596,7 +725,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e017_008750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e017_008750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 18,
@@ -608,7 +744,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e018_009250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e018_009250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 19,
@@ -620,7 +763,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e019_009750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e019_009750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 20,
@@ -632,7 +783,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e020_010250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e020_010250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 21,
@@ -644,7 +802,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e021_010750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e021_010750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 22,
@@ -656,7 +822,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 68,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e022_011250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e022_011250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 23,
@@ -668,7 +842,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e023_011750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e023_011750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 24,
@@ -680,7 +862,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e024_012250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e024_012250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 25,
@@ -692,7 +881,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e025_012750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e025_012750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 26,
@@ -704,7 +901,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 34,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e026_013250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e026_013250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 27,
@@ -716,7 +921,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e027_013750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e027_013750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 28,
@@ -728,7 +941,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e028_014250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e028_014250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 29,
@@ -740,7 +960,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e029_014750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e029_014750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 30,
@@ -752,7 +979,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e030_015250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e030_015250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 31,
@@ -764,7 +999,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e031_015750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e031_015750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 32,
@@ -776,7 +1019,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": -2,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e032_016250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e032_016250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 33,
@@ -788,7 +1038,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e033_016750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e033_016750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 34,
@@ -800,7 +1057,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e034_017250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e034_017250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 35,
@@ -812,7 +1076,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e035_017750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e035_017750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 36,
@@ -824,7 +1095,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e036_018250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e036_018250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 37,
@@ -836,7 +1115,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e037_018750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e037_018750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 38,
@@ -848,7 +1135,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e038_019250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e038_019250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 39,
@@ -860,7 +1154,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e039_019750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e039_019750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 40,
@@ -872,7 +1174,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e040_020250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e040_020250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 41,
@@ -884,7 +1193,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e041_020750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e041_020750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 42,
@@ -896,7 +1212,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e042_021250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e042_021250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 43,
@@ -908,7 +1231,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e043_021750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e043_021750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 44,
@@ -920,7 +1250,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e044_022250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e044_022250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 45,
@@ -932,7 +1269,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e045_022750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e045_022750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 46,
@@ -944,7 +1288,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e046_023250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e046_023250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 47,
@@ -956,7 +1308,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e047_023750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e047_023750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 48,
@@ -968,7 +1328,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e048_024250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e048_024250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 49,
@@ -980,7 +1348,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e049_024750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e049_024750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 50,
@@ -992,7 +1368,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e050_025250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e050_025250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 51,
@@ -1004,7 +1387,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e051_025750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e051_025750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 52,
@@ -1016,7 +1407,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e052_026250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e052_026250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 53,
@@ -1028,7 +1426,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 26,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e053_026750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e053_026750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 54,
@@ -1040,7 +1446,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e054_027250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e054_027250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 55,
@@ -1052,7 +1465,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e055_027750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e055_027750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 56,
@@ -1064,7 +1484,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 70,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e056_028250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e056_028250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 57,
@@ -1076,7 +1504,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e057_028750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e057_028750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 58,
@@ -1088,7 +1523,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e058_029250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e058_029250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 59,
@@ -1100,7 +1543,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e059_029750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e059_029750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 60,
@@ -1112,7 +1562,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e060_030250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e060_030250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 61,
@@ -1124,7 +1582,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e061_030750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e061_030750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 62,
@@ -1136,7 +1601,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e062_031250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e062_031250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 63,
@@ -1148,7 +1621,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e063_031750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e063_031750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 64,
@@ -1160,7 +1640,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e064_032250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e064_032250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 65,
@@ -1172,7 +1659,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e065_032750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e065_032750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 66,
@@ -1184,7 +1679,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 27,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e066_033250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e066_033250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 67,
@@ -1196,7 +1699,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e067_033750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e067_033750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 68,
@@ -1208,7 +1718,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e068_034250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e068_034250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 69,
@@ -1220,7 +1738,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 34,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e069_034750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e069_034750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 70,
@@ -1232,7 +1757,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e070_035250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e070_035250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 71,
@@ -1244,7 +1777,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e071_035750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e071_035750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 72,
@@ -1256,7 +1797,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e072_036250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e072_036250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 73,
@@ -1268,7 +1816,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 31,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e073_036750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e073_036750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 74,
@@ -1280,7 +1836,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e074_037250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e074_037250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 75,
@@ -1292,7 +1855,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 2,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e075_037750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e075_037750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 76,
@@ -1304,7 +1874,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e076_038250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e076_038250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 77,
@@ -1316,7 +1893,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e077_038750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e077_038750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 78,
@@ -1328,11 +1912,18 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 63,
-      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e078_039210_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jrvv7og65q7lr92if0_e078_039210_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     }
   ],
   "cycles": [
-    "Yellow Yellow Yellow Unknown↓ Unknown↓ Unknown↓ Blue Blue↓ Unknown Pink/Magenta↓ Yellow↓ Unknown↑ Unknown Unknown↑ Unknown↓ Pink/Magenta↑ Unknown Unknown Blue Unknown↓ Unknown Unknown↓ Unknown↓ Yellow↓ Unknown Unknown↑ Blue↓ Unknown↓ Yellow Yellow Yellow↑ Yellow↓ Unknown Yellow Unknown Unknown Yellow↓ Yellow↑ Yellow Yellow↑ Yellow Yellow Unknown Unknown Unknown Yellow Yellow↓ Yellow↓ Yellow↓ Yellow↓ Yellow Yellow↑ Unknown Pink/Magenta↓ Unknown Unknown Pink/Magenta↑ Yellow Yellow↑ Blue Unknown↓ Yellow Yellow↑ Unknown Yellow Unknown↓ Unknown↓ Unknown Yellow↓ Blue Yellow↑ Blue↓ Unknown Pink/Magenta↓ Unknown Unknown Unknown Unknown Unknown"
+    "Yellow V0 Yellow V0 Yellow V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Blue V0 Blue↓ V0 Unknown V0 Pink/Magenta↓ V0 Yellow↓ V0 Unknown↑ V0 Unknown V0 Unknown↑ V0 Unknown↓ V0 Pink/Magenta↑ V0 Unknown V0 Unknown V0 Blue V0 Unknown↓ V0 Unknown V0 Unknown↓ V0 Unknown↓ V0 Yellow↓ V0 Unknown V0 Unknown↑ V0 Blue↓ V0 Unknown↓ V0 Yellow V0 Yellow V0 Yellow↑ V0 Yellow↓ V0 Unknown V0 Yellow V0 Unknown V0 Unknown V0 Yellow↓ V0 Yellow↑ V0 Yellow V0 Yellow↑ V0 Yellow V0 Yellow V0 Unknown V0 Unknown V0 Unknown V0 Yellow V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow V0 Yellow↑ V0 Unknown V0 Pink/Magenta↓ V0 Unknown V0 Unknown V0 Pink/Magenta↑ V0 Yellow V0 Yellow↑ V0 Blue V0 Unknown↓ V0 Yellow V0 Yellow↑ V0 Unknown V0 Yellow V0 Unknown↓ V0 Unknown↓ V0 Unknown V0 Yellow↓ V0 Blue V0 Yellow↑ V0 Blue↓ V0 Unknown V0 Pink/Magenta↓ V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0"
   ],
   "clustering": {
     "eps": 0.34,

--- a/public/sequences_merge/v15044gf0000d2js9uvog65r8b9dc63g.json.sequence.json
+++ b/public/sequences_merge/v15044gf0000d2js9uvog65r8b9dc63g.json.sequence.json
@@ -429,7 +429,7 @@
     }
   },
   "symbol_seq": "_BCBBBB__AAN_CGAYBBBAEGBGBDNFFAATCPALAZCIARAJYAJLBDAUAATQNBDBDAVATKBBAEAGAGLLBDCAGTVTAFAIAHBDBDAFAHAHQKBDJTARABQQQQIALALBDBDHGBDCKBAQQKKQBBCLCBDHQAUXXQAQAQYKINNOPHQUMAEPLQQAYEQKCLGBCQAQLLADRNBDBBBBMAZRXWKKAOQAHJBBWJJHRPJ",
-  "symbol_seq_enhanced": "Blue↑ Green↑ Green↑ Green↑ Blue↑ Blue↑ Blue Blue Blue Blue↑ Blue Blue↑ Blue Unknown↑ Blue Blue↓ Blue↓ Blue↓ Blue Blue Blue Blue Blue Blue↓ Blue Blue↓ Blue Unknown↑ Blue↑ Yellow Green↓ Unknown Blue↓ Yellow Unknown Green Unknown Unknown Unknown Unknown Green Pink/Magenta Pink/Magenta↓ Unknown Blue↓ Unknown Unknown↓ Unknown↑ Unknown Unknown Green Blue Pink/Magenta Pink/Magenta Unknown↓ Unknown↑ Unknown Blue Pink/Magenta Pink/Magenta↓ Pink/Magenta↑ Pink/Magenta Pink/Magenta Pink/Magenta Blue↑ Yellow Unknown Unknown Pink/Magenta↓ Pink/Magenta↑ Pink/Magenta↑ Unknown Unknown Unknown Blue Pink/Magenta Unknown Pink/Magenta↓ Unknown Unknown Unknown↓ Unknown Yellow↓ Green Green Unknown Unknown Unknown Blue↑ Unknown Blue Unknown Unknown Unknown Unknown Unknown Unknown Unknown Blue↑ Green Unknown Blue↓ Unknown Yellow↑ Unknown Green Unknown Unknown Unknown Green Green Unknown Unknown↓ Yellow Blue↓ Blue↓ Blue↓ Yellow Yellow↓ Unknown↓ Yellow↓ Blue↓ Blue Yellow Unknown Unknown Unknown Green Unknown Unknown↑ Unknown↓ Blue Unknown Blue Green↑ Unknown↑ Green↑ Unknown Unknown Yellow Yellow Blue Unknown Green↓ Green↓ Blue Unknown Yellow Unknown↑ Yellow Unknown↑ Unknown↑ Green↑ Unknown Pink/Magenta Blue Green Yellow↑ Blue↑ Blue↑ Yellow Yellow Yellow↑ Blue",
+  "symbol_seq_enhanced": "Blue↑ V0 Green↑ V0 Green↑ V0 Green↑ V0 Blue↑ V0 Blue↑ V0 Blue V0 Blue V0 Blue V0 Blue↑ V0 Blue V0 Blue↑ V0 Blue V0 Unknown↑ V0 Blue V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue↓ V0 Blue V0 Blue↓ V0 Blue V0 Unknown↑ V0 Blue↑ V0 Yellow V0 Green↓ V0 Unknown V0 Blue↓ V0 Yellow V0 Unknown V0 Green V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Green V0 Pink/Magenta V0 Pink/Magenta↓ V0 Unknown V0 Blue↓ V0 Unknown V0 Unknown↓ V0 Unknown↑ V0 Unknown V0 Unknown V0 Green V0 Blue V0 Pink/Magenta V0 Pink/Magenta V0 Unknown↓ V0 Unknown↑ V0 Unknown V0 Blue V0 Pink/Magenta V0 Pink/Magenta↓ V0 Pink/Magenta↑ V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Blue↑ V0 Yellow V0 Unknown V0 Unknown V0 Pink/Magenta↓ V0 Pink/Magenta↑ V0 Pink/Magenta↑ V0 Unknown V0 Unknown V0 Unknown V0 Blue V0 Pink/Magenta V0 Unknown V0 Pink/Magenta↓ V0 Unknown V0 Unknown V0 Unknown↓ V0 Unknown V0 Yellow↓ V0 Green V0 Green V0 Unknown V0 Unknown V0 Unknown V0 Blue↑ V0 Unknown V0 Blue V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Blue↑ V0 Green V0 Unknown V0 Blue↓ V0 Unknown V0 Yellow↑ V0 Unknown V0 Green V0 Unknown V0 Unknown V0 Unknown V0 Green V0 Green V0 Unknown V0 Unknown↓ V0 Yellow V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Yellow V0 Yellow↓ V0 Unknown↓ V0 Yellow↓ V0 Blue↓ V0 Blue V0 Yellow V0 Unknown V0 Unknown V0 Unknown V0 Green V0 Unknown V0 Unknown↑ V0 Unknown↓ V0 Blue V0 Unknown V0 Blue V0 Green↑ V0 Unknown↑ V0 Green↑ V0 Unknown V0 Unknown V0 Yellow V0 Yellow V0 Blue V0 Unknown V0 Green↓ V0 Green↓ V0 Blue V0 Unknown V0 Yellow V0 Unknown↑ V0 Yellow V0 Unknown↑ V0 Unknown↑ V0 Green↑ V0 Unknown V0 Pink/Magenta V0 Blue V0 Green V0 Yellow↑ V0 Blue↑ V0 Blue↑ V0 Yellow V0 Yellow V0 Yellow↑ V0 Blue V0",
   "binary_seq": "00000001100000000000000000000000000011111111101110111101110101110011000000100000000000000000000000110111000000000011000001110000000001000000001000000000100100110001",
   "v_threshold": 0.529,
   "events": [
@@ -443,7 +443,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": -1,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e000_000250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e000_000250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 1,
@@ -455,7 +463,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 69,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e001_000750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e001_000750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 2,
@@ -467,7 +483,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 66,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e002_001250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e002_001250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 3,
@@ -479,7 +503,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 66,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e003_001750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e003_001750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 4,
@@ -491,7 +523,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": -1,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e004_002250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e004_002250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 5,
@@ -503,7 +543,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": -1,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e005_002750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e005_002750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 6,
@@ -515,7 +563,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e006_003250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e006_003250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 7,
@@ -527,7 +582,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e007_003750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e007_003750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 8,
@@ -539,7 +601,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e008_004250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e008_004250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 9,
@@ -551,7 +620,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": -1,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e009_004750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e009_004750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 10,
@@ -563,7 +640,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e010_005250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e010_005250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 11,
@@ -575,7 +659,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e011_005750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e011_005750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 12,
@@ -587,7 +679,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e012_006250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e012_006250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 13,
@@ -599,7 +698,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e013_006750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e013_006750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 14,
@@ -611,7 +718,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e014_007250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e014_007250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 15,
@@ -623,7 +737,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e015_007750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e015_007750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 16,
@@ -635,7 +757,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e016_008250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e016_008250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 17,
@@ -647,7 +777,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 34,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e017_008750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e017_008750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 18,
@@ -659,7 +797,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e018_009250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e018_009250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 19,
@@ -671,7 +816,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e019_009750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e019_009750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 20,
@@ -683,7 +835,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e020_010250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e020_010250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 21,
@@ -695,7 +854,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e021_010750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e021_010750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 22,
@@ -707,7 +873,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e022_011250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e022_011250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 23,
@@ -719,7 +892,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e023_011750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e023_011750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 24,
@@ -731,7 +912,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e024_012250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e024_012250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 25,
@@ -743,7 +931,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e025_012750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e025_012750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 26,
@@ -755,7 +951,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e026_013250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e026_013250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 27,
@@ -767,7 +970,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 32,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e027_013750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e027_013750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 28,
@@ -779,7 +990,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e028_014250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e028_014250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 29,
@@ -791,7 +1010,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e029_014750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e029_014750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 30,
@@ -803,7 +1029,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 1,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e030_015250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e030_015250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 31,
@@ -815,7 +1049,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 68,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e031_015750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e031_015750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 32,
@@ -827,7 +1068,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e032_016250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e032_016250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 33,
@@ -839,7 +1088,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e033_016750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e033_016750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 34,
@@ -851,7 +1107,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 42,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e034_017250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e034_017250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 35,
@@ -863,7 +1126,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 24,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e035_017750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e035_017750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 36,
@@ -875,7 +1145,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e036_018250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e036_018250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 37,
@@ -887,7 +1164,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 24,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e037_018750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e037_018750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 38,
@@ -899,7 +1183,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e038_019250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e038_019250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 39,
@@ -911,7 +1202,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 59,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e039_019750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e039_019750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 40,
@@ -923,7 +1221,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 56,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e040_020250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e040_020250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 41,
@@ -935,7 +1240,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 70,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e041_020750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e041_020750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 42,
@@ -947,7 +1259,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e042_021250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e042_021250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 43,
@@ -959,7 +1279,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e043_021750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e043_021750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 44,
@@ -971,7 +1298,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e044_022250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e044_022250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 45,
@@ -983,7 +1318,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 59,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e045_022750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e045_022750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 46,
@@ -995,7 +1337,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 59,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e046_023250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e046_023250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 47,
@@ -1007,7 +1357,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 53,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e047_023750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e047_023750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 48,
@@ -1019,7 +1377,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 32,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e048_024250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e048_024250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 49,
@@ -1031,7 +1396,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e049_024750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e049_024750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 50,
@@ -1043,7 +1415,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 66,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e050_025250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e050_025250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 51,
@@ -1055,7 +1434,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 34,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e051_025750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e051_025750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 52,
@@ -1067,7 +1453,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 26,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e052_026250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e052_026250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 53,
@@ -1079,7 +1472,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 26,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e053_026750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e053_026750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 54,
@@ -1091,7 +1491,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e054_027250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e054_027250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 55,
@@ -1103,7 +1511,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e055_027750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e055_027750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 56,
@@ -1115,7 +1531,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 59,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e056_028250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e056_028250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 57,
@@ -1127,7 +1550,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e057_028750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e057_028750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 58,
@@ -1139,7 +1569,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 26,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e058_029250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e058_029250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 59,
@@ -1151,7 +1588,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e059_029750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e059_029750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 60,
@@ -1163,7 +1608,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 15,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e060_030250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e060_030250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 61,
@@ -1175,7 +1628,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e061_030750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e061_030750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 62,
@@ -1187,7 +1647,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 54,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e062_031250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e062_031250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 63,
@@ -1199,7 +1666,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 67,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e063_031750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e063_031750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 64,
@@ -1211,7 +1685,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e064_032250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e064_032250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 65,
@@ -1223,7 +1705,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e065_032750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e065_032750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 66,
@@ -1235,7 +1724,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 59,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e066_033250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e066_033250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 67,
@@ -1247,7 +1743,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 59,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e067_033750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e067_033750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 68,
@@ -1259,7 +1762,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 54,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e068_034250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e068_034250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 69,
@@ -1271,7 +1782,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 31,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e069_034750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e069_034750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 70,
@@ -1283,7 +1802,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 31,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e070_035250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e070_035250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 71,
@@ -1295,7 +1822,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e071_035750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e071_035750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 72,
@@ -1307,7 +1841,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e072_036250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e072_036250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 73,
@@ -1319,7 +1860,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 59,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e073_036750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e073_036750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 74,
@@ -1331,7 +1879,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e074_037250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e074_037250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 75,
@@ -1343,7 +1898,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 62,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e075_037750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e075_037750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 76,
@@ -1355,7 +1917,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 42,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e076_038250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e076_038250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 77,
@@ -1367,7 +1936,15 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 44,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e077_038750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e077_038750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 78,
@@ -1379,7 +1956,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e078_039250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e078_039250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 79,
@@ -1391,7 +1975,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e079_039750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e079_039750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 80,
@@ -1403,7 +1994,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e080_040250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e080_040250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 81,
@@ -1415,7 +2014,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e081_040750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e081_040750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 82,
@@ -1427,7 +2033,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e082_041250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e082_041250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 83,
@@ -1439,7 +2053,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 1,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e083_041750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e083_041750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 84,
@@ -1451,7 +2072,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 1,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e084_042250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e084_042250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 85,
@@ -1463,7 +2091,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 59,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e085_042750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e085_042750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 86,
@@ -1475,7 +2110,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 59,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e086_043250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e086_043250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 87,
@@ -1487,7 +2129,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e087_043750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e087_043750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 88,
@@ -1499,7 +2148,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e088_044250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e088_044250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 89,
@@ -1511,7 +2168,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 59,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e089_044750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e089_044750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 90,
@@ -1523,7 +2187,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e090_045250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e090_045250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 91,
@@ -1535,7 +2206,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e091_045750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e091_045750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 92,
@@ -1547,7 +2225,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 61,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e092_046250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e092_046250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 93,
@@ -1559,7 +2244,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e093_046750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e093_046750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 94,
@@ -1571,7 +2263,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e094_047250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e094_047250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 95,
@@ -1583,7 +2282,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e095_047750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e095_047750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 96,
@@ -1595,7 +2301,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e096_048250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e096_048250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 97,
@@ -1607,7 +2320,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e097_048750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e097_048750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 98,
@@ -1619,7 +2339,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e098_049250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e098_049250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 99,
@@ -1631,7 +2359,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 69,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e099_049750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e099_049750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 100,
@@ -1643,7 +2378,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e100_050250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e100_050250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 101,
@@ -1655,7 +2397,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e101_050750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e101_050750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 102,
@@ -1667,7 +2417,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 59,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e102_051250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e102_051250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 103,
@@ -1679,7 +2436,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e103_051750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e103_051750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 104,
@@ -1691,7 +2456,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e104_052250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e104_052250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 105,
@@ -1703,7 +2475,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 56,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e105_052750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e105_052750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 106,
@@ -1715,7 +2494,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 2,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e106_053250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e106_053250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 107,
@@ -1727,7 +2513,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 2,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e107_053750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e107_053750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 108,
@@ -1739,7 +2532,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e108_054250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e108_054250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 109,
@@ -1751,7 +2551,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 65,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e109_054750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e109_054750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 110,
@@ -1763,7 +2570,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 65,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e110_055250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e110_055250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 111,
@@ -1775,7 +2589,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e111_055750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e111_055750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 112,
@@ -1787,7 +2608,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e112_056250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e112_056250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 113,
@@ -1799,7 +2628,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e113_056750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e113_056750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 114,
@@ -1811,7 +2647,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e114_057250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e114_057250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 115,
@@ -1823,7 +2667,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e115_057750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e115_057750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 116,
@@ -1835,7 +2687,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e116_058250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e116_058250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 117,
@@ -1847,7 +2707,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e117_058750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e117_058750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 118,
@@ -1859,7 +2726,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e118_059250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e118_059250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 119,
@@ -1871,7 +2746,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e119_059750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e119_059750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 120,
@@ -1883,7 +2766,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e120_060250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e120_060250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 121,
@@ -1895,7 +2786,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e121_060750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e121_060750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 122,
@@ -1907,7 +2806,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 34,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e122_061250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e122_061250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 123,
@@ -1919,7 +2825,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e123_061750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e123_061750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 124,
@@ -1931,7 +2844,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e124_062250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e124_062250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 125,
@@ -1943,7 +2863,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e125_062750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e125_062750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 126,
@@ -1955,7 +2882,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e126_063250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e126_063250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 127,
@@ -1967,7 +2901,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 45,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e127_063750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e127_063750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 128,
@@ -1979,7 +2920,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e128_064250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e128_064250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 129,
@@ -1991,7 +2939,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e129_064750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e129_064750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 130,
@@ -2003,7 +2959,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e130_065250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e130_065250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 131,
@@ -2015,7 +2979,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e131_065750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e131_065750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 132,
@@ -2027,7 +2998,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e132_066250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e132_066250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 133,
@@ -2039,7 +3017,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e133_066750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e133_066750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 134,
@@ -2051,7 +3036,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 69,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e134_067250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e134_067250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 135,
@@ -2063,7 +3056,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e135_067750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e135_067750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 136,
@@ -2075,7 +3076,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 65,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e136_068250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e136_068250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 137,
@@ -2087,7 +3096,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e137_068750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e137_068750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 138,
@@ -2099,7 +3115,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e138_069250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e138_069250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 139,
@@ -2111,7 +3134,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 5,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e139_069750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e139_069750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 140,
@@ -2123,7 +3153,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e140_070250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e140_070250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 141,
@@ -2135,7 +3172,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e141_070750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e141_070750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 142,
@@ -2147,7 +3191,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 59,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e142_071250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e142_071250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 143,
@@ -2159,7 +3210,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 66,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e143_071750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e143_071750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 144,
@@ -2171,7 +3230,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 66,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e144_072250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e144_072250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 145,
@@ -2183,7 +3250,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e145_072750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e145_072750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 146,
@@ -2195,7 +3269,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 68,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e146_073250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e146_073250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 147,
@@ -2207,7 +3288,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e147_073750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e147_073750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 148,
@@ -2219,7 +3307,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 2,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e148_074250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e148_074250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 149,
@@ -2231,7 +3327,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e149_074750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e149_074750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 150,
@@ -2243,7 +3346,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e150_075250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e150_075250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 151,
@@ -2255,7 +3366,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e151_075750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e151_075750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 152,
@@ -2267,7 +3386,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 41,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e152_076250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e152_076250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 153,
@@ -2279,7 +3406,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e153_076750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e153_076750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 154,
@@ -2291,7 +3425,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 31,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e154_077250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e154_077250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 155,
@@ -2303,7 +3444,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e155_077750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e155_077750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 156,
@@ -2315,7 +3463,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 66,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e156_078250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e156_078250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 157,
@@ -2327,7 +3482,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e157_078750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e157_078750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 158,
@@ -2339,7 +3502,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e158_079250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e158_079250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 159,
@@ -2351,7 +3522,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e159_079750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e159_079750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 160,
@@ -2363,7 +3542,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e160_080250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e160_080250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 161,
@@ -2375,7 +3561,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e161_080750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e161_080750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 162,
@@ -2387,7 +3580,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e162_081250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e162_081250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 163,
@@ -2399,11 +3600,18 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e163_081750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2js9uvog65r8b9dc63g_e163_081750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     }
   ],
   "cycles": [
-    "Blue↑ Green↑ Green↑ Green↑ Blue↑ Blue↑ Blue Blue Blue Blue↑ Blue Blue↑ Blue Unknown↑ Blue Blue↓ Blue↓ Blue↓ Blue Blue Blue Blue Blue Blue↓ Blue Blue↓ Blue Unknown↑ Blue↑ Yellow Green↓ Unknown Blue↓ Yellow Unknown Green Unknown Unknown Unknown Unknown Green Pink/Magenta Pink/Magenta↓ Unknown Blue↓ Unknown Unknown↓ Unknown↑ Unknown Unknown Green Blue Pink/Magenta Pink/Magenta Unknown↓ Unknown↑ Unknown Blue Pink/Magenta Pink/Magenta↓ Pink/Magenta↑ Pink/Magenta Pink/Magenta Pink/Magenta Blue↑ Yellow Unknown Unknown Pink/Magenta↓ Pink/Magenta↑ Pink/Magenta↑ Unknown Unknown Unknown Blue Pink/Magenta Unknown Pink/Magenta↓ Unknown Unknown Unknown↓ Unknown Yellow↓ Green Green Unknown Unknown Unknown Blue↑ Unknown Blue Unknown Unknown Unknown Unknown Unknown Unknown Unknown Blue↑ Green Unknown Blue↓ Unknown Yellow↑ Unknown Green Unknown Unknown Unknown Green Green Unknown Unknown↓ Yellow Blue↓ Blue↓ Blue↓ Yellow Yellow↓ Unknown↓ Yellow↓ Blue↓ Blue Yellow Unknown Unknown Unknown Green Unknown Unknown↑ Unknown↓ Blue Unknown Blue Green↑ Unknown↑ Green↑ Unknown Unknown Yellow Yellow Blue Unknown Green↓ Green↓ Blue Unknown Yellow Unknown↑ Yellow Unknown↑ Unknown↑ Green↑ Unknown Pink/Magenta Blue Green Yellow↑ Blue↑ Blue↑ Yellow Yellow Yellow↑ Blue"
+    "Blue↑ V0 Green↑ V0 Green↑ V0 Green↑ V0 Blue↑ V0 Blue↑ V0 Blue V0 Blue V0 Blue V0 Blue↑ V0 Blue V0 Blue↑ V0 Blue V0 Unknown↑ V0 Blue V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue V0 Blue↓ V0 Blue V0 Blue↓ V0 Blue V0 Unknown↑ V0 Blue↑ V0 Yellow V0 Green↓ V0 Unknown V0 Blue↓ V0 Yellow V0 Unknown V0 Green V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Green V0 Pink/Magenta V0 Pink/Magenta↓ V0 Unknown V0 Blue↓ V0 Unknown V0 Unknown↓ V0 Unknown↑ V0 Unknown V0 Unknown V0 Green V0 Blue V0 Pink/Magenta V0 Pink/Magenta V0 Unknown↓ V0 Unknown↑ V0 Unknown V0 Blue V0 Pink/Magenta V0 Pink/Magenta↓ V0 Pink/Magenta↑ V0 Pink/Magenta V0 Pink/Magenta V0 Pink/Magenta V0 Blue↑ V0 Yellow V0 Unknown V0 Unknown V0 Pink/Magenta↓ V0 Pink/Magenta↑ V0 Pink/Magenta↑ V0 Unknown V0 Unknown V0 Unknown V0 Blue V0 Pink/Magenta V0 Unknown V0 Pink/Magenta↓ V0 Unknown V0 Unknown V0 Unknown↓ V0 Unknown V0 Yellow↓ V0 Green V0 Green V0 Unknown V0 Unknown V0 Unknown V0 Blue↑ V0 Unknown V0 Blue V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Unknown V0 Blue↑ V0 Green V0 Unknown V0 Blue↓ V0 Unknown V0 Yellow↑ V0 Unknown V0 Green V0 Unknown V0 Unknown V0 Unknown V0 Green V0 Green V0 Unknown V0 Unknown↓ V0 Yellow V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Yellow V0 Yellow↓ V0 Unknown↓ V0 Yellow↓ V0 Blue↓ V0 Blue V0 Yellow V0 Unknown V0 Unknown V0 Unknown V0 Green V0 Unknown V0 Unknown↑ V0 Unknown↓ V0 Blue V0 Unknown V0 Blue V0 Green↑ V0 Unknown↑ V0 Green↑ V0 Unknown V0 Unknown V0 Yellow V0 Yellow V0 Blue V0 Unknown V0 Green↓ V0 Green↓ V0 Blue V0 Unknown V0 Yellow V0 Unknown↑ V0 Yellow V0 Unknown↑ V0 Unknown↑ V0 Green↑ V0 Unknown V0 Pink/Magenta V0 Blue V0 Green V0 Yellow↑ V0 Blue↑ V0 Blue↑ V0 Yellow V0 Yellow V0 Yellow↑ V0 Blue V0"
   ],
   "clustering": {
     "eps": 0.34,

--- a/public/sequences_merge/v15044gf0000d2jt6u7og65s1kh4jhq0.json.sequence.json
+++ b/public/sequences_merge/v15044gf0000d2jt6u7og65s1kh4jhq0.json.sequence.json
@@ -293,7 +293,7 @@
     }
   },
   "symbol_seq": "___UADFCPGGGGCZCCJZMGMAHAGAHAHGCGOJJCZCZMJIEHHGGJGAEAEBHBHIAHGASOOUDASMMICCAENMGCADU",
-  "symbol_seq_enhanced": "Yellow↓ Yellow↓ Yellow↓ Yellow↓ Yellow↓ Blue↑ Blue↑ Yellow↓ Blue Blue Blue↑ Blue↑ Blue Blue↓ Blue↑ Blue Blue↑ Blue↓ Blue↓ Blue↑ Blue↑ Pink/Magenta Blue↓ Blue↓ Pink/Magenta Pink/Magenta Blue Blue Blue↓ Blue Blue↓ Blue↓ Blue↑ Blue Blue↓ Blue↓ Blue↑ Blue↑ Yellow↓ Unknown↓ Yellow↓ Yellow↓ Blue↑ Blue↑ Blue↑ Blue Blue Blue↓ Blue↑ Yellow Blue↑ Yellow↓ Yellow↓ Blue↓ Yellow↓ Blue Unknown↓ Blue↑ Blue↑ Yellow Blue↓ Unknown↓ Blue↑ Blue↑ Yellow↑ Blue↓ Blue↓ Blue↓ Blue Blue↓ Blue Blue↓ Yellow↑ Yellow↑",
+  "symbol_seq_enhanced": "Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Blue↑ V0 Blue↑ V0 Yellow↓ V0 Blue V0 Blue V0 Blue↑ V0 Blue↑ V0 Blue V0 Blue↓ V0 Blue↑ V0 Blue V0 Blue↑ V0 Blue↓ V0 Blue↓ V0 Blue↑ V0 Blue↑ V0 Pink/Magenta V0 Blue↓ V0 Blue↓ V0 Pink/Magenta V0 Pink/Magenta V0 Blue V0 Blue V0 Blue↓ V0 Blue V0 Blue↓ V0 Blue↓ V0 Blue↑ V0 Blue V0 Blue↓ V0 Blue↓ V0 Blue↑ V0 Blue↑ V0 Yellow↓ V0 Unknown↓ V0 Yellow↓ V0 Yellow↓ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue V0 Blue V0 Blue↓ V0 Blue↑ V0 Yellow V0 Blue↑ V0 Yellow↓ V0 Yellow↓ V0 Blue↓ V0 Yellow↓ V0 Blue V0 Unknown↓ V0 Blue↑ V0 Blue↑ V0 Yellow V0 Blue↓ V0 Unknown↓ V0 Blue↑ V0 Blue↑ V0 Yellow↑ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue V0 Blue↓ V0 Blue V0 Blue↓ V0 Yellow↑ V0 Yellow↑ V0",
   "binary_seq": "00000010000001100001101011101011011001000000110000100001000001000000000000",
   "v_threshold": 0.522,
   "events": [
@@ -307,7 +307,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": -8,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e000_000250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e000_000250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 1,
@@ -319,7 +327,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": -9,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e001_000750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e001_000750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 2,
@@ -331,7 +347,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": -9,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e002_001250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e002_001250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 3,
@@ -343,7 +367,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e003_001750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e003_001750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 4,
@@ -355,7 +387,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 5,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e004_002250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e004_002250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 5,
@@ -367,7 +407,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e005_002750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e005_002750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 6,
@@ -379,7 +427,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e006_003250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e006_003250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 7,
@@ -391,7 +447,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e007_003750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e007_003750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 8,
@@ -403,7 +467,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e008_004250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e008_004250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 9,
@@ -415,7 +486,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e009_004750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e009_004750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 10,
@@ -427,7 +505,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e010_005250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e010_005250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 11,
@@ -439,7 +525,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e011_005750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e011_005750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 12,
@@ -451,7 +545,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e012_006250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e012_006250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 13,
@@ -463,7 +564,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 49,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e013_006750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e013_006750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 14,
@@ -475,7 +584,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e014_007250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e014_007250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 15,
@@ -487,7 +604,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e015_007750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e015_007750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 16,
@@ -499,7 +623,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e016_008250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e016_008250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 17,
@@ -511,7 +643,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 49,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e017_008750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e017_008750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 18,
@@ -523,7 +663,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e018_009250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e018_009250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 19,
@@ -535,7 +683,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e019_009750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e019_009750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 20,
@@ -547,7 +703,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e020_010250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e020_010250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 21,
@@ -559,7 +723,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 31,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e021_010750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e021_010750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 22,
@@ -571,7 +742,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e022_011250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e022_011250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 23,
@@ -583,7 +762,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e023_011750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e023_011750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 24,
@@ -595,7 +782,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 31,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e024_012250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e024_012250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 25,
@@ -607,7 +801,14 @@
       "flash": false,
       "color_label": "Pink/Magenta",
       "cluster_id": 31,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e025_012750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e025_012750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Pink/Magenta V0"
     },
     {
       "event_index": 26,
@@ -619,7 +820,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e026_013250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e026_013250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 27,
@@ -631,7 +839,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e027_013750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e027_013750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 28,
@@ -643,7 +858,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e028_014250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e028_014250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 29,
@@ -655,7 +878,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e029_014750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e029_014750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 30,
@@ -667,7 +897,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e030_015250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e030_015250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 31,
@@ -679,7 +917,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e031_015750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e031_015750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 32,
@@ -691,7 +937,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e032_016250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e032_016250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 33,
@@ -703,7 +957,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 49,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e033_016750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e033_016750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 34,
@@ -715,7 +976,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e034_017250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e034_017250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 35,
@@ -727,7 +996,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 49,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e035_017750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e035_017750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 36,
@@ -739,7 +1016,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e036_018250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e036_018250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 37,
@@ -751,7 +1036,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e037_018750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e037_018750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 38,
@@ -763,7 +1056,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e038_019250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e038_019250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 39,
@@ -775,7 +1076,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e039_019750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e039_019750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 40,
@@ -787,7 +1096,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e040_020250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e040_020250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 41,
@@ -799,7 +1116,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e041_020750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e041_020750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 42,
@@ -811,7 +1136,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e042_021250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e042_021250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 43,
@@ -823,7 +1156,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e043_021750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e043_021750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 44,
@@ -835,7 +1176,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 40,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e044_022250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e044_022250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 45,
@@ -847,7 +1196,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e045_022750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e045_022750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 46,
@@ -859,7 +1215,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 34,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e046_023250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e046_023250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 47,
@@ -871,7 +1234,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 34,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e047_023750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e047_023750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 48,
@@ -883,7 +1254,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e048_024250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e048_024250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 49,
@@ -895,7 +1274,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e049_024750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e049_024750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 50,
@@ -907,7 +1293,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 37,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e050_025250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e050_025250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 51,
@@ -919,7 +1313,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e051_025750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e051_025750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 52,
@@ -931,7 +1333,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e052_026250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e052_026250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 53,
@@ -943,7 +1353,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e053_026750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e053_026750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 54,
@@ -955,7 +1373,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e054_027250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e054_027250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 55,
@@ -967,7 +1393,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e055_027750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e055_027750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 56,
@@ -979,7 +1412,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 64,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e056_028250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e056_028250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 57,
@@ -991,7 +1432,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e057_028750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e057_028750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 58,
@@ -1003,7 +1452,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e058_029250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e058_029250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 59,
@@ -1015,7 +1472,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e059_029750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e059_029750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 60,
@@ -1027,7 +1491,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e060_030250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e060_030250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 61,
@@ -1039,7 +1511,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 64,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e061_030750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e061_030750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 62,
@@ -1051,7 +1531,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e062_031250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e062_031250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 63,
@@ -1063,7 +1551,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e063_031750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e063_031750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 64,
@@ -1075,7 +1571,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e064_032250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e064_032250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 65,
@@ -1087,7 +1591,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e065_032750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e065_032750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 66,
@@ -1099,7 +1611,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e066_033250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e066_033250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 67,
@@ -1111,7 +1631,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 34,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e067_033750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e067_033750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 68,
@@ -1123,7 +1651,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 17,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e068_034250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e068_034250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 69,
@@ -1135,7 +1670,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 19,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e069_034750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e069_034750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 70,
@@ -1147,7 +1690,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e070_035250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e070_035250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 71,
@@ -1159,7 +1709,15 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 3,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e071_035750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e071_035750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 72,
@@ -1171,7 +1729,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 5,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e072_036250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e072_036250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 73,
@@ -1183,11 +1749,19 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e073_036700_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt6u7og65s1kh4jhq0_e073_036700_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     }
   ],
   "cycles": [
-    "Yellow↓ Yellow↓ Yellow↓ Yellow↓ Yellow↓ Blue↑ Blue↑ Yellow↓ Blue Blue Blue↑ Blue↑ Blue Blue↓ Blue↑ Blue Blue↑ Blue↓ Blue↓ Blue↑ Blue↑ Pink/Magenta Blue↓ Blue↓ Pink/Magenta Pink/Magenta Blue Blue Blue↓ Blue Blue↓ Blue↓ Blue↑ Blue Blue↓ Blue↓ Blue↑ Blue↑ Yellow↓ Unknown↓ Yellow↓ Yellow↓ Blue↑ Blue↑ Blue↑ Blue Blue Blue↓ Blue↑ Yellow Blue↑ Yellow↓ Yellow↓ Blue↓ Yellow↓ Blue Unknown↓ Blue↑ Blue↑ Yellow Blue↓ Unknown↓ Blue↑ Blue↑ Yellow↑ Blue↓ Blue↓ Blue↓ Blue Blue↓ Blue Blue↓ Yellow↑ Yellow↑"
+    "Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Blue↑ V0 Blue↑ V0 Yellow↓ V0 Blue V0 Blue V0 Blue↑ V0 Blue↑ V0 Blue V0 Blue↓ V0 Blue↑ V0 Blue V0 Blue↑ V0 Blue↓ V0 Blue↓ V0 Blue↑ V0 Blue↑ V0 Pink/Magenta V0 Blue↓ V0 Blue↓ V0 Pink/Magenta V0 Pink/Magenta V0 Blue V0 Blue V0 Blue↓ V0 Blue V0 Blue↓ V0 Blue↓ V0 Blue↑ V0 Blue V0 Blue↓ V0 Blue↓ V0 Blue↑ V0 Blue↑ V0 Yellow↓ V0 Unknown↓ V0 Yellow↓ V0 Yellow↓ V0 Blue↑ V0 Blue↑ V0 Blue↑ V0 Blue V0 Blue V0 Blue↓ V0 Blue↑ V0 Yellow V0 Blue↑ V0 Yellow↓ V0 Yellow↓ V0 Blue↓ V0 Yellow↓ V0 Blue V0 Unknown↓ V0 Blue↑ V0 Blue↑ V0 Yellow V0 Blue↓ V0 Unknown↓ V0 Blue↑ V0 Blue↑ V0 Yellow↑ V0 Blue↓ V0 Blue↓ V0 Blue↓ V0 Blue V0 Blue↓ V0 Blue V0 Blue↓ V0 Yellow↑ V0 Yellow↑ V0"
   ],
   "clustering": {
     "eps": 0.34,

--- a/public/sequences_merge/v15044gf0000d2jt9vfog65vjgteco5g.json.sequence.json
+++ b/public/sequences_merge/v15044gf0000d2jt9vfog65vjgteco5g.json.sequence.json
@@ -276,7 +276,7 @@
     }
   },
   "symbol_seq": "RFDAYWWRRUPUHIWIIIEHIRIRKRRRIREHHEIIRUAOEQOBDQGF",
-  "symbol_seq_enhanced": "Yellow↓ Blue Blue Blue Unknown Yellow↓ Yellow↓ Yellow↓ Yellow Yellow↓ Yellow Yellow Yellow Yellow Yellow Yellow↓ Yellow↓ Yellow↓ Unknown Yellow↑ Yellow↑ Yellow Yellow↑ Yellow Unknown↓ Yellow Yellow Yellow Yellow Yellow↑ Unknown Yellow↑ Yellow Unknown↑ Yellow↓ Yellow↓ Yellow↓ Yellow↑ Green Unknown↓ Unknown Blue Unknown↑ Unknown Blue Blue",
+  "symbol_seq_enhanced": "Yellow↓ V0 Blue V0 Blue V0 Blue V0 Unknown V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow V0 Yellow↓ V0 Yellow V0 Yellow V0 Yellow V0 Yellow V0 Yellow V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Unknown V0 Yellow↑ V0 Yellow↑ V0 Yellow V0 Yellow↑ V0 Yellow V0 Unknown↓ V0 Yellow V0 Yellow V0 Yellow V0 Yellow V0 Yellow↑ V0 Unknown V0 Yellow↑ V0 Yellow V0 Unknown↑ V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow↑ V0 Green V0 Unknown↓ V0 Unknown V0 Blue V0 Unknown↑ V0 Unknown V0 Blue V0 Blue V0",
   "binary_seq": "1100011111100000000000000000001101000110000010",
   "v_threshold": 0.5840000000000001,
   "events": [
@@ -290,7 +290,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e000_000250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e000_000250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 1,
@@ -302,7 +310,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e001_000750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e001_000750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 2,
@@ -314,7 +329,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 51,
-      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e002_001250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e002_001250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 3,
@@ -326,7 +348,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 48,
-      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e003_001750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e003_001750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 4,
@@ -338,7 +367,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 55,
-      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e004_002250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e004_002250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 5,
@@ -350,7 +386,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e005_002750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e005_002750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 6,
@@ -362,7 +406,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e006_003250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e006_003250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 7,
@@ -374,7 +426,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e007_003750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e007_003750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 8,
@@ -386,7 +446,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e008_004250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e008_004250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 9,
@@ -398,7 +465,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e009_004750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e009_004750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 10,
@@ -410,7 +485,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e010_005250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e010_005250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 11,
@@ -422,7 +504,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e011_005750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e011_005750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 12,
@@ -434,7 +523,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e012_006250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e012_006250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 13,
@@ -446,7 +542,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e013_006750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e013_006750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 14,
@@ -458,7 +561,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e014_007250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e014_007250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 15,
@@ -470,7 +580,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e015_007750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e015_007750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 16,
@@ -482,7 +600,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e016_008250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e016_008250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 17,
@@ -494,7 +620,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e017_008750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e017_008750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 18,
@@ -506,7 +640,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e018_009250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e018_009250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 19,
@@ -518,7 +659,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e019_009750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e019_009750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 20,
@@ -530,7 +679,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e020_010250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e020_010250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 21,
@@ -542,7 +699,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e021_010750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e021_010750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 22,
@@ -554,7 +718,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e022_011250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e022_011250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 23,
@@ -566,7 +738,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e023_011750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e023_011750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 24,
@@ -578,7 +757,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e024_012250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e024_012250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 25,
@@ -590,7 +777,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e025_012750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e025_012750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 26,
@@ -602,7 +796,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e026_013250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e026_013250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 27,
@@ -614,7 +815,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e027_013750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e027_013750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 28,
@@ -626,7 +834,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e028_014250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e028_014250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 29,
@@ -638,7 +853,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e029_014750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e029_014750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 30,
@@ -650,7 +873,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e030_015250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e030_015250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 31,
@@ -662,7 +892,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e031_015750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e031_015750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 32,
@@ -674,7 +912,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e032_016250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e032_016250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 33,
@@ -686,7 +931,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e033_016750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e033_016750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 34,
@@ -698,7 +951,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e034_017250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e034_017250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 35,
@@ -710,7 +971,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e035_017750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e035_017750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 36,
@@ -722,7 +991,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e036_018250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e036_018250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 37,
@@ -734,7 +1011,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e037_018750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e037_018750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 38,
@@ -746,7 +1031,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 41,
-      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e038_019250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e038_019250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 39,
@@ -758,7 +1050,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e039_019750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e039_019750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 40,
@@ -770,7 +1070,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e040_020250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e040_020250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 41,
@@ -782,7 +1089,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 35,
-      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e041_020750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e041_020750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 42,
@@ -794,7 +1108,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 59,
-      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e042_021250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e042_021250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 43,
@@ -806,7 +1128,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e043_021750_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e043_021750_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 44,
@@ -818,7 +1147,14 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 39,
-      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e044_022250_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e044_022250_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     },
     {
       "event_index": 45,
@@ -830,11 +1166,18 @@
       "flash": false,
       "color_label": "Blue",
       "cluster_id": 22,
-      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e045_022749_obj.jpg"
+      "thumb_obj": "v15044gf0000d2jt9vfog65vjgteco5g_e045_022749_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Blue V0"
     }
   ],
   "cycles": [
-    "Yellow↓ Blue Blue Blue Unknown Yellow↓ Yellow↓ Yellow↓ Yellow Yellow↓ Yellow Yellow Yellow Yellow Yellow Yellow↓ Yellow↓ Yellow↓ Unknown Yellow↑ Yellow↑ Yellow Yellow↑ Yellow Unknown↓ Yellow Yellow Yellow Yellow Yellow↑ Unknown Yellow↑ Yellow Unknown↑ Yellow↓ Yellow↓ Yellow↓ Yellow↑ Green Unknown↓ Unknown Blue Unknown↑ Unknown Blue Blue"
+    "Yellow↓ V0 Blue V0 Blue V0 Blue V0 Unknown V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow V0 Yellow↓ V0 Yellow V0 Yellow V0 Yellow V0 Yellow V0 Yellow V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Unknown V0 Yellow↑ V0 Yellow↑ V0 Yellow V0 Yellow↑ V0 Yellow V0 Unknown↓ V0 Yellow V0 Yellow V0 Yellow V0 Yellow V0 Yellow↑ V0 Unknown V0 Yellow↑ V0 Yellow V0 Unknown↑ V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow↑ V0 Green V0 Unknown↓ V0 Unknown V0 Blue V0 Unknown↑ V0 Unknown V0 Blue V0 Blue V0"
   ],
   "clustering": {
     "eps": 0.34,

--- a/public/sequences_merge/v24044gl0000d2het8fog65gpmg3gr4g.json.sequence.json
+++ b/public/sequences_merge/v24044gl0000d2het8fog65gpmg3gr4g.json.sequence.json
@@ -344,7 +344,7 @@
     }
   },
   "symbol_seq": "PLLIEAPAPAJBCAMWANPRANQXLEEKLWLHREUEIIIIRIKQQADKRWWRAOLLQQLQKEHKQQQQQAMAPQKKKQHEELLEADLLEEKKEAMAMLEEHKKHHEIRIUIIPHRPPURPEHHIRIHPAPAVELLARALALU_PPWLREEUUQ",
-  "symbol_seq_enhanced": "Yellow↓ Unknown↑ Unknown↑ Yellow↓ Unknown↑ Unknown↑ Unknown↑ Green↓ Green↓ Unknown↓ Yellow↓ Unknown↓ Yellow Yellow↓ Unknown Unknown↑ Unknown↓ Unknown↑ Unknown↑ Unknown↑ Unknown↑ Unknown Yellow↑ Unknown↑ Yellow Yellow Unknown↑ Yellow↑ Unknown↑ Yellow↑ Yellow Yellow↑ Yellow↑ Yellow↑ Yellow↑ Unknown↑ Unknown↑ Unknown↑ Yellow↓ Unknown Yellow↓ Yellow↑ Yellow↑ Yellow↑ Green Unknown↓ Unknown Unknown Unknown Unknown↑ Unknown↑ Unknown↑ Unknown↑ Yellow Unknown↑ Unknown↑ Unknown Unknown↑ Unknown↑ Unknown↑ Unknown Unknown↓ Unknown↑ Unknown Unknown↑ Unknown↑ Unknown↑ Yellow↑ Unknown↑ Unknown↑ Unknown↑ Unknown↑ Unknown↑ Yellow Unknown↑ Unknown↑ Unknown↑ Unknown↑ Unknown Unknown↑ Unknown↑ Unknown↑ Unknown↑ Unknown Unknown↑ Unknown↑ Unknown↑ Unknown↑ Unknown↑ Yellow↓ Yellow↓ Unknown↓ Yellow↓ Yellow↓ Yellow↓ Yellow↓ Yellow↓ Yellow↓ Yellow↓ Yellow↓ Yellow↓ Yellow↓ Yellow↓ Yellow↓ Yellow↓ Yellow↓ Unknown↓ Unknown↓ Unknown↓ Yellow↓ Yellow↓ Yellow↓ Yellow↓ Yellow↓ Unknown↓ Unknown↓ Unknown↓ Unknown↑ Unknown↑ Unknown↓ Green↓ Green↓ Yellow↓ Green↓ Yellow↓ Yellow↓ Yellow↓ Unknown↑ Yellow↓ Unknown↓ Unknown↓ Yellow↓ Yellow↓ Unknown↑",
+  "symbol_seq_enhanced": "Yellow↓ V0 Unknown↑ V0 Unknown↑ V0 Yellow↓ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Green↓ V0 Green↓ V0 Unknown↓ V0 Yellow↓ V0 Unknown↓ V0 Yellow V0 Yellow↓ V0 Unknown V0 Unknown↑ V0 Unknown↓ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown V0 Yellow↑ V0 Unknown↑ V0 Yellow V0 Yellow V0 Unknown↑ V0 Yellow↑ V0 Unknown↑ V0 Yellow↑ V0 Yellow V0 Yellow↑ V0 Yellow↑ V0 Yellow↑ V0 Yellow↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Yellow↓ V0 Unknown V0 Yellow↓ V0 Yellow↑ V0 Yellow↑ V0 Yellow↑ V0 Green V0 Unknown↓ V0 Unknown V0 Unknown V0 Unknown V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Yellow V0 Unknown↑ V0 Unknown↑ V0 Unknown V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown V0 Unknown↓ V0 Unknown↑ V0 Unknown V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Yellow↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Yellow V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Yellow↓ V0 Yellow↓ V0 Unknown↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Unknown↑ V0 Unknown↑ V0 Unknown↓ V0 Green↓ V0 Green↓ V0 Yellow↓ V0 Green↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Unknown↑ V0 Yellow↓ V0 Unknown↓ V0 Unknown↓ V0 Yellow↓ V0 Yellow↓ V0 Unknown↑ V0",
   "binary_seq": "01101110000000010111111100000000000111010000011111111111111100111111111110111111111111011000000000000000000000000000011000000001000001",
   "v_threshold": 0.516,
   "events": [
@@ -358,7 +358,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e000_000500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e000_000500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 1,
@@ -370,7 +378,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e001_001500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e001_001500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 2,
@@ -382,7 +398,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e002_002500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e002_002500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 3,
@@ -394,7 +418,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e003_003500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e003_003500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 4,
@@ -406,7 +438,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e004_004500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e004_004500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 5,
@@ -418,7 +458,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 9,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e005_005500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e005_005500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 6,
@@ -430,7 +478,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 9,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e006_006500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e006_006500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 7,
@@ -442,7 +498,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 24,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e007_007500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e007_007500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 8,
@@ -454,7 +518,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 69,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e008_008500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e008_008500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 9,
@@ -466,7 +538,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 7,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e009_009500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e009_009500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 10,
@@ -478,7 +558,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e010_010500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e010_010500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 11,
@@ -490,7 +578,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 27,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e011_011500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e011_011500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 12,
@@ -502,7 +598,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e012_012500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e012_012500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 13,
@@ -514,7 +617,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e013_013500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e013_013500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 14,
@@ -526,7 +637,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 27,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e014_014500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e014_014500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 15,
@@ -538,7 +656,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e015_015500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e015_015500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 16,
@@ -550,7 +676,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 2,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e016_016500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e016_016500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 17,
@@ -562,7 +696,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e017_017500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e017_017500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 18,
@@ -574,7 +716,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e018_018500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e018_018500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 19,
@@ -586,7 +736,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e019_019500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e019_019500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 20,
@@ -598,7 +756,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e020_020500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e020_020500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 21,
@@ -610,7 +776,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e021_021500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e021_021500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 22,
@@ -622,7 +795,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e022_022500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e022_022500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 23,
@@ -634,7 +815,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e023_023500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e023_023500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 24,
@@ -646,7 +835,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e024_024500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e024_024500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 25,
@@ -658,7 +854,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e025_025500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e025_025500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 26,
@@ -670,7 +873,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e026_026500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e026_026500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 27,
@@ -682,7 +893,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e027_027500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e027_027500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 28,
@@ -694,7 +913,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e028_028500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e028_028500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 29,
@@ -706,7 +933,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e029_029500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e029_029500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 30,
@@ -718,7 +953,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e030_030500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e030_030500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 31,
@@ -730,7 +972,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e031_031500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e031_031500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 32,
@@ -742,7 +992,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e032_032500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e032_032500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 33,
@@ -754,7 +1012,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e033_033500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e033_033500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 34,
@@ -766,7 +1032,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e034_034500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e034_034500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 35,
@@ -778,7 +1052,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e035_035500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e035_035500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 36,
@@ -790,7 +1072,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e036_036500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e036_036500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 37,
@@ -802,7 +1092,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e037_037500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e037_037500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 38,
@@ -814,7 +1112,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 5,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e038_038500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e038_038500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 39,
@@ -826,7 +1132,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e039_039500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e039_039500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 40,
@@ -838,7 +1151,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e040_040500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e040_040500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 41,
@@ -850,7 +1171,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e041_041500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e041_041500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 42,
@@ -862,7 +1191,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e042_042500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e042_042500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 43,
@@ -874,7 +1211,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e043_043500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e043_043500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 44,
@@ -886,7 +1231,14 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 41,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e044_044500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e044_044500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green V0"
     },
     {
       "event_index": 45,
@@ -898,7 +1250,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e045_045500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e045_045500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 46,
@@ -910,7 +1270,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e046_046500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e046_046500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 47,
@@ -922,7 +1289,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e047_047500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e047_047500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 48,
@@ -934,7 +1308,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e048_048500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e048_048500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 49,
@@ -946,7 +1327,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e049_049500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e049_049500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 50,
@@ -958,7 +1347,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e050_050500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e050_050500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 51,
@@ -970,7 +1367,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e051_051500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e051_051500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 52,
@@ -982,7 +1387,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e052_052500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e052_052500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 53,
@@ -994,7 +1407,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e053_053500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e053_053500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 54,
@@ -1006,7 +1426,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e054_054500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e054_054500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 55,
@@ -1018,7 +1446,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e055_055500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e055_055500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 56,
@@ -1030,7 +1466,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e056_056500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e056_056500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 57,
@@ -1042,7 +1485,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e057_057500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e057_057500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 58,
@@ -1054,7 +1505,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e058_058500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e058_058500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 59,
@@ -1066,7 +1525,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e059_059500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e059_059500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 60,
@@ -1078,7 +1545,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 7,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e060_060500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e060_060500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 61,
@@ -1090,7 +1564,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 9,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e061_061500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e061_061500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 62,
@@ -1102,7 +1584,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e062_062500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e062_062500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 63,
@@ -1114,7 +1604,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e063_063500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e063_063500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 64,
@@ -1126,7 +1623,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e064_064500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e064_064500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 65,
@@ -1138,7 +1643,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e065_065500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e065_065500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 66,
@@ -1150,7 +1663,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e066_066500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e066_066500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 67,
@@ -1162,7 +1683,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e067_067500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e067_067500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 68,
@@ -1174,7 +1703,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e068_068500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e068_068500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 69,
@@ -1186,7 +1723,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e069_069500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e069_069500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 70,
@@ -1198,7 +1743,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e070_070500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e070_070500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 71,
@@ -1210,7 +1763,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e071_071500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e071_071500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 72,
@@ -1222,7 +1783,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e072_072500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e072_072500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 73,
@@ -1234,7 +1803,14 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 5,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e073_073500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e073_073500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow V0"
     },
     {
       "event_index": 74,
@@ -1246,7 +1822,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e074_074500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e074_074500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 75,
@@ -1258,7 +1842,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e075_075500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e075_075500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 76,
@@ -1270,7 +1862,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e076_076500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e076_076500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 77,
@@ -1282,7 +1882,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e077_077500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e077_077500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 78,
@@ -1294,7 +1902,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e078_078500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e078_078500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 79,
@@ -1306,7 +1921,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e079_079500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e079_079500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 80,
@@ -1318,7 +1941,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e080_080500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e080_080500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 81,
@@ -1330,7 +1961,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 7,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e081_081500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e081_081500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 82,
@@ -1342,7 +1981,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 7,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e082_082500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e082_082500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 83,
@@ -1354,7 +2001,14 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e083_083500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e083_083500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown V0"
     },
     {
       "event_index": 84,
@@ -1366,7 +2020,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e084_084500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e084_084500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 85,
@@ -1378,7 +2040,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e085_085500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e085_085500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 86,
@@ -1390,7 +2060,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 0,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e086_086500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e086_086500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 87,
@@ -1402,7 +2080,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e087_087500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e087_087500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 88,
@@ -1414,7 +2100,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 13,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e088_088500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e088_088500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 89,
@@ -1426,7 +2120,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e089_089500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e089_089500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 90,
@@ -1438,7 +2140,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e090_090500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e090_090500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 91,
@@ -1450,7 +2160,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e091_091500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e091_091500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 92,
@@ -1462,7 +2180,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e092_092500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e092_092500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 93,
@@ -1474,7 +2200,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e093_093500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e093_093500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 94,
@@ -1486,7 +2220,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e094_094500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e094_094500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 95,
@@ -1498,7 +2240,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e095_095500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e095_095500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 96,
@@ -1510,7 +2260,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e096_096500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e096_096500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 97,
@@ -1522,7 +2280,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e097_097500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e097_097500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 98,
@@ -1534,7 +2300,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e098_098500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e098_098500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 99,
@@ -1546,7 +2320,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e099_099500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e099_099500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 100,
@@ -1558,7 +2340,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e100_100500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e100_100500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 101,
@@ -1570,7 +2360,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e101_101500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e101_101500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 102,
@@ -1582,7 +2380,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e102_102500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e102_102500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 103,
@@ -1594,7 +2400,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e103_103500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e103_103500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 104,
@@ -1606,7 +2420,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e104_104500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e104_104500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 105,
@@ -1618,7 +2440,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e105_105500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e105_105500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 106,
@@ -1630,7 +2460,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e106_106500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e106_106500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 107,
@@ -1642,7 +2480,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 0,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e107_107500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e107_107500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 108,
@@ -1654,7 +2500,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 0,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e108_108500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e108_108500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 109,
@@ -1666,7 +2520,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e109_109500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e109_109500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 110,
@@ -1678,7 +2540,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e110_110500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e110_110500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 111,
@@ -1690,7 +2560,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 12,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e111_111500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e111_111500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 112,
@@ -1702,7 +2580,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 0,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e112_112500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e112_112500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 113,
@@ -1714,7 +2600,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e113_113500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e113_113500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 114,
@@ -1726,7 +2620,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 9,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e114_114500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e114_114500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 115,
@@ -1738,7 +2640,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 53,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e115_115500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e115_115500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 116,
@@ -1750,7 +2660,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e116_116500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e116_116500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 117,
@@ -1762,7 +2680,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e117_117500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e117_117500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 118,
@@ -1774,7 +2700,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e118_118500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e118_118500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 119,
@@ -1786,7 +2720,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 42,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e119_119500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e119_119500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 120,
@@ -1798,7 +2740,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 1,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e120_120500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e120_120500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 121,
@@ -1810,7 +2760,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": 1,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e121_121500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e121_121500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 122,
@@ -1822,7 +2780,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e122_122500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e122_122500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 123,
@@ -1834,7 +2800,15 @@
       "flash": false,
       "color_label": "Green",
       "cluster_id": -7,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e123_123500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e123_123500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Green↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 124,
@@ -1846,7 +2820,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e124_124500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e124_124500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 125,
@@ -1858,7 +2840,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 20,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e125_125500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e125_125500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 126,
@@ -1870,7 +2860,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 4,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e126_126500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e126_126500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 127,
@@ -1882,7 +2880,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 71,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e127_127500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e127_127500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     },
     {
       "event_index": 128,
@@ -1894,7 +2900,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 30,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e128_128500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e128_128500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 129,
@@ -1906,7 +2920,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e129_129500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e129_129500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 130,
@@ -1918,7 +2940,15 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 8,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e130_130500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e130_130500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 131,
@@ -1930,7 +2960,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e131_131500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e131_131500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 132,
@@ -1942,7 +2980,15 @@
       "flash": false,
       "color_label": "Yellow",
       "cluster_id": 28,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e132_132500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e132_132500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Yellow↓ V0",
+      "arrow": "↓"
     },
     {
       "event_index": 133,
@@ -1954,11 +3000,19 @@
       "flash": false,
       "color_label": "Unknown",
       "cluster_id": 46,
-      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e133_133500_obj.jpg"
+      "thumb_obj": "v24044gl0000d2het8fog65gpmg3gr4g_e133_133500_obj.jpg",
+      "orientation8": null,
+      "sector8": null,
+      "vacuole_angles_deg": [],
+      "vacuole_sectors8": [],
+      "vacuole_mask8": 0,
+      "vacuole_count": 0,
+      "enhanced_token": "Unknown↑ V0",
+      "arrow": "↑"
     }
   ],
   "cycles": [
-    "Yellow↓ Unknown↑ Unknown↑ Yellow↓ Unknown↑ Unknown↑ Unknown↑ Green↓ Green↓ Unknown↓ Yellow↓ Unknown↓ Yellow Yellow↓ Unknown Unknown↑ Unknown↓ Unknown↑ Unknown↑ Unknown↑ Unknown↑ Unknown Yellow↑ Unknown↑ Yellow Yellow Unknown↑ Yellow↑ Unknown↑ Yellow↑ Yellow Yellow↑ Yellow↑ Yellow↑ Yellow↑ Unknown↑ Unknown↑ Unknown↑ Yellow↓ Unknown Yellow↓ Yellow↑ Yellow↑ Yellow↑ Green Unknown↓ Unknown Unknown Unknown Unknown↑ Unknown↑ Unknown↑ Unknown↑ Yellow Unknown↑ Unknown↑ Unknown Unknown↑ Unknown↑ Unknown↑ Unknown Unknown↓ Unknown↑ Unknown Unknown↑ Unknown↑ Unknown↑ Yellow↑ Unknown↑ Unknown↑ Unknown↑ Unknown↑ Unknown↑ Yellow Unknown↑ Unknown↑ Unknown↑ Unknown↑ Unknown Unknown↑ Unknown↑ Unknown↑ Unknown↑ Unknown Unknown↑ Unknown↑ Unknown↑ Unknown↑ Unknown↑ Yellow↓ Yellow↓ Unknown↓ Yellow↓ Yellow↓ Yellow↓ Yellow↓ Yellow↓ Yellow↓ Yellow↓ Yellow↓ Yellow↓ Yellow↓ Yellow↓ Yellow↓ Yellow↓ Yellow↓ Unknown↓ Unknown↓ Unknown↓ Yellow↓ Yellow↓ Yellow↓ Yellow↓ Yellow↓ Unknown↓ Unknown↓ Unknown↓ Unknown↑ Unknown↑ Unknown↓ Green↓ Green↓ Yellow↓ Green↓ Yellow↓ Yellow↓ Yellow↓ Unknown↑ Yellow↓ Unknown↓ Unknown↓ Yellow↓ Yellow↓ Unknown↑"
+    "Yellow↓ V0 Unknown↑ V0 Unknown↑ V0 Yellow↓ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Green↓ V0 Green↓ V0 Unknown↓ V0 Yellow↓ V0 Unknown↓ V0 Yellow V0 Yellow↓ V0 Unknown V0 Unknown↑ V0 Unknown↓ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown V0 Yellow↑ V0 Unknown↑ V0 Yellow V0 Yellow V0 Unknown↑ V0 Yellow↑ V0 Unknown↑ V0 Yellow↑ V0 Yellow V0 Yellow↑ V0 Yellow↑ V0 Yellow↑ V0 Yellow↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Yellow↓ V0 Unknown V0 Yellow↓ V0 Yellow↑ V0 Yellow↑ V0 Yellow↑ V0 Green V0 Unknown↓ V0 Unknown V0 Unknown V0 Unknown V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Yellow V0 Unknown↑ V0 Unknown↑ V0 Unknown V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown V0 Unknown↓ V0 Unknown↑ V0 Unknown V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Yellow↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Yellow V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Unknown↑ V0 Yellow↓ V0 Yellow↓ V0 Unknown↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Unknown↓ V0 Unknown↓ V0 Unknown↓ V0 Unknown↑ V0 Unknown↑ V0 Unknown↓ V0 Green↓ V0 Green↓ V0 Yellow↓ V0 Green↓ V0 Yellow↓ V0 Yellow↓ V0 Yellow↓ V0 Unknown↑ V0 Yellow↓ V0 Unknown↓ V0 Unknown↓ V0 Yellow↓ V0 Yellow↓ V0 Unknown↑ V0"
   ],
   "clustering": {
     "eps": 0.34,


### PR DESCRIPTION
## Summary
- enrich each sequence event with orientation/vacuole placeholders, arrow hints, and derived enhanced_token strings
- regenerate symbol_seq_enhanced and cycle summaries so they match the radial metadata layout expected by the viewer

## Testing
- not run (data-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d9b25486d88327a02b8b69aa114c0c