### PR TITLE
Add machine-readable count badge for atlas viewer

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -578,7 +578,7 @@
 <body>
     <header style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">
         <h1>UAP / Orb Atlas Viewer</h1>
-        <span id="countBadge" class="badge">0 items</span>
+        <span id="countBadge" class="badge" data-count="0">0 items</span>
         <span id="visitorsBadge" class="badge">— visitors</span>
         <span id="note" class="badge">View: All • Sort: Hue ↑</span>
         <!-- NEW: monetization buttons -->
@@ -1394,6 +1394,13 @@ updateStatus();
         const $ = sel => document.querySelector(sel);
         const gridEl = $("#grid"), note = $("#note"), countBadge = $("#countBadge"), sentinel = $("#sentinel");
 
+        function setCountBadge(total) {
+            if (!countBadge) return;
+            const value = Number.isFinite(total) ? total : 0;
+            countBadge.dataset.count = String(value);
+            countBadge.textContent = `${value.toLocaleString()} items`;
+        }
+
         const STYLE_ALIASES = {
             default: ["", "_outline", "_smooth", "_bezier", "_skeleton", "_rings", "_hull", "_edges", "_ellipse", "_contour", "_convex"],
             outline: ["_outline", "_contour"], smooth: ["_smooth"], bezier: ["_bezier"], skeleton: ["_skeleton"], rings: ["_rings"],
@@ -1681,7 +1688,7 @@ updateStatus();
             gridEl.insertAdjacentHTML("beforeend", frag);
             wireTileClicks(start, end);
             stream.i = end;
-            countBadge.textContent = `${CURRENT.length} items`;
+            setCountBadge(CURRENT.length);
             if (stream.i >= CURRENT.length && stream.observer) { stream.observer.disconnect(); stream.observer = null; }
         }
 
@@ -1735,7 +1742,7 @@ updateStatus();
                 });
             });
             wireTileClicks(0, gridEl.querySelectorAll(".card").length);
-            countBadge.textContent = `${total} items`;
+            setCountBadge(total);
             currentView = "grouped"; updateNote();
             const sEl = document.getElementById("status"); if (sEl) sEl.textContent = "";
         }

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -13,8 +13,9 @@ test.describe('Orb Atlas Viewer – smoke', () => {
         await page.getByRole('button', { name: 'Reset' }).click();
 
         // Count badge repopulates (> 0)
-        const count = await page.locator('#countBadge').innerText();
-        expect(Number(count)).toBeGreaterThan(0);
+        const countAttr = await page.locator('#countBadge').getAttribute('data-count');
+        const count = Number(countAttr ?? '0');
+        expect(count).toBeGreaterThan(0);
 
         // Defaults
         await expect(page.locator('#groupSelect')).toHaveValue('video');
@@ -41,7 +42,7 @@ test.describe('Orb Atlas Viewer – smoke', () => {
             throw error;
         }
 
-        const initialCount = Number(await page.locator('#countBadge').innerText());
+        const initialCount = Number(await page.locator('#countBadge').getAttribute('data-count') ?? '0');
         expect(initialCount).toBeGreaterThan(0);
 
         // Click first card's Similar button
@@ -49,8 +50,12 @@ test.describe('Orb Atlas Viewer – smoke', () => {
         await firstSim.click();
 
         // After similar view, count should be <= 31 (1 + top 30)
-        await page.waitForFunction(() => Number(document.querySelector('#countBadge')?.textContent || '0') > 0);
-        const afterCount = Number(await page.locator('#countBadge').innerText());
+        await page.waitForFunction(() => {
+            const el = document.querySelector('#countBadge');
+            const raw = el?.getAttribute('data-count') ?? '0';
+            return Number(raw) > 0;
+        });
+        const afterCount = Number(await page.locator('#countBadge').getAttribute('data-count') ?? '0');
         expect(afterCount).toBeLessThanOrEqual(31);
     });
 


### PR DESCRIPTION
## Summary
- add a numeric data-count attribute to the atlas viewer count badge so the UI can display a friendly label while exposing machine-readable counts
- centralize count badge updates in the viewer script to keep the attribute in sync for both streaming and grouped views
- update the smoke test assertions to use the new data-count attribute instead of parsing the rendered text

## Testing
- npm test *(fails: Playwright browser binaries are unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d9d173cf30832785681077dfa9287d