### PR TITLE
Fix cluster popup asset base injection

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1032,7 +1032,6 @@
                     }
                 })();
                 const safeAssetBaseAttr = String(assetBase || '/').replace(/"/g, '&quot;');
-                const assetBaseLiteral = JSON.stringify(assetBase || '/');
                 if (win.closed) return;
                     const html = `<!doctype html>
 <html lang="en">
@@ -1073,7 +1072,7 @@ main { padding:18px; }
   <div id="clusterGrid" class="grid hidden" aria-live="polite"></div>
 </main>
 <script>
-const ASSET_BASE = ${assetBaseLiteral};
+const ASSET_BASE = ${JSON.stringify(assetBase || '/')};
 const state = { map: new Map(), expected: 0, done: false };
 const gridEl = document.getElementById('clusterGrid');
 const statusEl = document.getElementById('clusterStatus');


### PR DESCRIPTION
## Summary
- inline the computed asset base when bootstrapping the cluster popup script so thumbnail URLs resolve from the opener

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1860ae31c8327ba244b084ab70671